### PR TITLE
Fit glyphs on the monowidth

### DIFF
--- a/sources/RobotoMono-Bold.ufo/glyphs/D_croat.glif
+++ b/sources/RobotoMono-Bold.ufo/glyphs/D_croat.glif
@@ -1,51 +1,51 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Dcroat" format="2">
-  <advance width="1259"/>
+  <advance width="1229"/>
   <unicode hex="0110"/>
   <outline>
     <contour>
-      <point x="155" y="0" type="line"/>
-      <point x="155" y="643" type="line"/>
-      <point x="-27" y="643" type="line"/>
-      <point x="-27" y="823" type="line"/>
-      <point x="155" y="823" type="line"/>
-      <point x="155" y="1456" type="line"/>
-      <point x="532" y="1456" type="line" smooth="yes"/>
-      <point x="677" y="1456"/>
-      <point x="912" y="1357"/>
-      <point x="995.5" y="1268.5" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="1079" y="1180"/>
-      <point x="1170" y="934"/>
-      <point x="1170" y="787" type="qcurve" smooth="yes"/>
-      <point x="1170" y="667" type="line" smooth="yes"/>
-      <point x="1170" y="520"/>
-      <point x="1079" y="275"/>
-      <point x="997.0" y="186.5" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="915" y="98"/>
-      <point x="685" y="0"/>
-      <point x="546" y="0" type="qcurve" smooth="yes"/>
+      <point x="140" y="0" type="line"/>
+      <point x="140" y="643" type="line"/>
+      <point x="-42" y="643" type="line"/>
+      <point x="-42" y="823" type="line"/>
+      <point x="140" y="823" type="line"/>
+      <point x="140" y="1456" type="line"/>
+      <point x="517" y="1456" type="line" smooth="yes"/>
+      <point x="662" y="1456"/>
+      <point x="897" y="1357"/>
+      <point x="981" y="1269" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="1064" y="1180"/>
+      <point x="1155" y="934"/>
+      <point x="1155" y="787" type="qcurve" smooth="yes"/>
+      <point x="1155" y="667" type="line" smooth="yes"/>
+      <point x="1155" y="520"/>
+      <point x="1064" y="275"/>
+      <point x="982.0" y="187" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="900" y="98"/>
+      <point x="670" y="0"/>
+      <point x="531" y="0" type="qcurve" smooth="yes"/>
     </contour>
     <contour>
-      <point x="665" y="643" type="line"/>
-      <point x="438" y="643" type="line"/>
-      <point x="438" y="226" type="line"/>
-      <point x="546" y="226" type="line" smooth="yes"/>
-      <point x="625" y="226"/>
-      <point x="750" y="286"/>
-      <point x="793.5" y="343.0" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="837" y="400"/>
-      <point x="883" y="563"/>
-      <point x="883" y="667" type="qcurve" smooth="yes"/>
-      <point x="883" y="789" type="line" smooth="yes"/>
-      <point x="883" y="887"/>
-      <point x="838" y="1048"/>
-      <point x="793.5" y="1106.0" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="749" y="1164"/>
-      <point x="618" y="1228"/>
-      <point x="532" y="1228" type="qcurve" smooth="yes"/>
-      <point x="438" y="1228" type="line"/>
-      <point x="438" y="823" type="line"/>
-      <point x="665" y="823" type="line"/>
+      <point x="650" y="643" type="line"/>
+      <point x="423" y="643" type="line"/>
+      <point x="423" y="226" type="line"/>
+      <point x="531" y="226" type="line" smooth="yes"/>
+      <point x="610" y="226"/>
+      <point x="735" y="286"/>
+      <point x="779" y="343.0" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="822" y="400"/>
+      <point x="868" y="563"/>
+      <point x="868" y="667" type="qcurve" smooth="yes"/>
+      <point x="868" y="789" type="line" smooth="yes"/>
+      <point x="868" y="887"/>
+      <point x="823" y="1048"/>
+      <point x="779" y="1106.0" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="734" y="1164"/>
+      <point x="603" y="1228"/>
+      <point x="517" y="1228" type="qcurve" smooth="yes"/>
+      <point x="423" y="1228" type="line"/>
+      <point x="423" y="823" type="line"/>
+      <point x="650" y="823" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Bold.ufo/glyphs/E_psilontonos.glif
+++ b/sources/RobotoMono-Bold.ufo/glyphs/E_psilontonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Epsilontonos" format="2">
-  <advance width="1329"/>
+  <advance width="1229"/>
   <unicode hex="0388"/>
   <outline>
-    <component base="E" xOffset="100"/>
-    <component base="tonos" xOffset="-715" yOffset="2"/>
+    <component base="E" xOffset="80"/>
+    <component base="tonos" xOffset="-685" yOffset="2"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Bold.ufo/glyphs/E_tatonos.glif
+++ b/sources/RobotoMono-Bold.ufo/glyphs/E_tatonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etatonos" format="2">
-  <advance width="1329"/>
+  <advance width="1229"/>
   <unicode hex="0389"/>
   <outline>
-    <component base="H" xOffset="100"/>
-    <component base="tonos" xOffset="-689" yOffset="-2"/>
+    <component base="H" xOffset="94"/>
+    <component base="tonos" xOffset="-665" yOffset="-2"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Bold.ufo/glyphs/E_th.glif
+++ b/sources/RobotoMono-Bold.ufo/glyphs/E_th.glif
@@ -1,51 +1,51 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Eth" format="2">
-  <advance width="1259"/>
+  <advance width="1229"/>
   <unicode hex="00D0"/>
   <outline>
     <contour>
-      <point x="155" y="0" type="line"/>
-      <point x="155" y="643" type="line"/>
-      <point x="-27" y="643" type="line"/>
-      <point x="-27" y="823" type="line"/>
-      <point x="155" y="823" type="line"/>
-      <point x="155" y="1456" type="line"/>
-      <point x="532" y="1456" type="line" smooth="yes"/>
-      <point x="677" y="1456"/>
-      <point x="912" y="1357"/>
-      <point x="995.5" y="1268.5" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="1079" y="1180"/>
-      <point x="1170" y="934"/>
-      <point x="1170" y="787" type="qcurve" smooth="yes"/>
-      <point x="1170" y="667" type="line" smooth="yes"/>
-      <point x="1170" y="520"/>
-      <point x="1079" y="275"/>
-      <point x="997.0" y="186.5" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="915" y="98"/>
-      <point x="685" y="0"/>
-      <point x="546" y="0" type="qcurve" smooth="yes"/>
+      <point x="140" y="0" type="line"/>
+      <point x="140" y="643" type="line"/>
+      <point x="-42" y="643" type="line"/>
+      <point x="-42" y="823" type="line"/>
+      <point x="140" y="823" type="line"/>
+      <point x="140" y="1456" type="line"/>
+      <point x="517" y="1456" type="line" smooth="yes"/>
+      <point x="662" y="1456"/>
+      <point x="897" y="1357"/>
+      <point x="981" y="1269" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="1064" y="1180"/>
+      <point x="1155" y="934"/>
+      <point x="1155" y="787" type="qcurve" smooth="yes"/>
+      <point x="1155" y="667" type="line" smooth="yes"/>
+      <point x="1155" y="520"/>
+      <point x="1064" y="275"/>
+      <point x="982.0" y="187" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="900" y="98"/>
+      <point x="670" y="0"/>
+      <point x="531" y="0" type="qcurve" smooth="yes"/>
     </contour>
     <contour>
-      <point x="665" y="643" type="line"/>
-      <point x="438" y="643" type="line"/>
-      <point x="438" y="226" type="line"/>
-      <point x="546" y="226" type="line" smooth="yes"/>
-      <point x="625" y="226"/>
-      <point x="750" y="286"/>
-      <point x="793.5" y="343.0" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="837" y="400"/>
-      <point x="883" y="563"/>
-      <point x="883" y="667" type="qcurve" smooth="yes"/>
-      <point x="883" y="789" type="line" smooth="yes"/>
-      <point x="883" y="887"/>
-      <point x="838" y="1048"/>
-      <point x="793.5" y="1106.0" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="749" y="1164"/>
-      <point x="618" y="1228"/>
-      <point x="532" y="1228" type="qcurve" smooth="yes"/>
-      <point x="438" y="1228" type="line"/>
-      <point x="438" y="823" type="line"/>
-      <point x="665" y="823" type="line"/>
+      <point x="650" y="643" type="line"/>
+      <point x="423" y="643" type="line"/>
+      <point x="423" y="226" type="line"/>
+      <point x="531" y="226" type="line" smooth="yes"/>
+      <point x="610" y="226"/>
+      <point x="735" y="286"/>
+      <point x="779" y="343.0" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="822" y="400"/>
+      <point x="868" y="563"/>
+      <point x="868" y="667" type="qcurve" smooth="yes"/>
+      <point x="868" y="789" type="line" smooth="yes"/>
+      <point x="868" y="887"/>
+      <point x="823" y="1048"/>
+      <point x="779" y="1106.0" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="734" y="1164"/>
+      <point x="603" y="1228"/>
+      <point x="517" y="1228" type="qcurve" smooth="yes"/>
+      <point x="423" y="1228" type="line"/>
+      <point x="423" y="823" type="line"/>
+      <point x="650" y="823" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Bold.ufo/glyphs/I_otatonos.glif
+++ b/sources/RobotoMono-Bold.ufo/glyphs/I_otatonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Iotatonos" format="2">
-  <advance width="1329"/>
+  <advance width="1229"/>
   <unicode hex="038A"/>
   <outline>
-    <component base="I" xOffset="100"/>
-    <component base="tonos" xOffset="-642" yOffset="2"/>
+    <component base="I" xOffset="27"/>
+    <component base="tonos" xOffset="-665" yOffset="2"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Bold.ufo/glyphs/O_megatonos.glif
+++ b/sources/RobotoMono-Bold.ufo/glyphs/O_megatonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegatonos" format="2">
-  <advance width="1249"/>
+  <advance width="1229"/>
   <unicode hex="038F"/>
   <outline>
-    <component base="Omega" xOffset="20"/>
-    <component base="tonos" xOffset="-656"/>
+    <component base="Omega" xOffset="10"/>
+    <component base="tonos" xOffset="-666"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Bold.ufo/glyphs/O_microntonos.glif
+++ b/sources/RobotoMono-Bold.ufo/glyphs/O_microntonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omicrontonos" format="2">
-  <advance width="1249"/>
+  <advance width="1229"/>
   <unicode hex="038C"/>
   <outline>
-    <component base="O" xOffset="20"/>
-    <component base="tonos" xOffset="-703"/>
+    <component base="O" xOffset="10"/>
+    <component base="tonos" xOffset="-693"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Bold.ufo/glyphs/U_psilontonos.glif
+++ b/sources/RobotoMono-Bold.ufo/glyphs/U_psilontonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Upsilontonos" format="2">
-  <advance width="1329"/>
+  <advance width="1229"/>
   <unicode hex="038E"/>
   <outline>
-    <component base="Y" xOffset="100"/>
-    <component base="tonos" xOffset="-759"/>
+    <component base="Y" xOffset="104" yOffset="1"/>
+    <component base="tonos" xOffset="-715" yOffset="1"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Bold.ufo/glyphs/acutecomb.glif
+++ b/sources/RobotoMono-Bold.ufo/glyphs/acutecomb.glif
@@ -1,6 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="acutecomb" format="2">
-  <advance width="1229"/>
   <unicode hex="0301"/>
   <outline>
     <contour>

--- a/sources/RobotoMono-Bold.ufo/glyphs/dcaron.glif
+++ b/sources/RobotoMono-Bold.ufo/glyphs/dcaron.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="dcaron" format="2">
-  <advance width="1379"/>
+  <advance width="1229"/>
   <unicode hex="010F"/>
   <outline>
-    <component base="d"/>
-    <component base="quoteright" xOffset="792"/>
+    <component base="d" xOffset="-72"/>
+    <component base="quoteright" xOffset="626"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Bold.ufo/glyphs/dcroat.glif
+++ b/sources/RobotoMono-Bold.ufo/glyphs/dcroat.glif
@@ -1,75 +1,75 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="dcroat" format="2">
-  <advance width="1259"/>
+  <advance width="1229"/>
   <unicode hex="0111"/>
   <outline>
     <contour>
-      <point x="1249" y="1220" type="line"/>
-      <point x="1080" y="1220" type="line"/>
-      <point x="1080" y="0" type="line"/>
-      <point x="829" y="0" type="line"/>
-      <point x="815" y="113" type="line"/>
-      <point x="795" y="88"/>
-      <point x="748" y="46"/>
-      <point x="722" y="30" type="qcurve" smooth="yes"/>
-      <point x="683" y="6"/>
-      <point x="590" y="-20"/>
-      <point x="535" y="-20" type="qcurve" smooth="yes"/>
-      <point x="436" y="-20"/>
-      <point x="279" y="63"/>
-      <point x="225" y="136" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="170" y="209"/>
-      <point x="112" y="410"/>
-      <point x="112" y="528" type="qcurve" smooth="yes"/>
-      <point x="112" y="549" type="line" smooth="yes"/>
-      <point x="112" y="672"/>
-      <point x="169" y="876"/>
-      <point x="224" y="949" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="279" y="1022"/>
-      <point x="436" y="1102"/>
-      <point x="537" y="1102" type="qcurve" smooth="yes"/>
-      <point x="593" y="1102"/>
-      <point x="688" y="1075"/>
-      <point x="728" y="1049" type="qcurve" smooth="yes"/>
-      <point x="747" y="1036"/>
-      <point x="784" y="1004"/>
-      <point x="801" y="985" type="qcurve"/>
-      <point x="801" y="1220" type="line"/>
-      <point x="557" y="1220" type="line"/>
-      <point x="557" y="1400" type="line"/>
-      <point x="801" y="1400" type="line"/>
-      <point x="801" y="1536" type="line"/>
-      <point x="1080" y="1536" type="line"/>
-      <point x="1080" y="1400" type="line"/>
-      <point x="1249" y="1400" type="line"/>
+      <point x="1234" y="1220" type="line"/>
+      <point x="1065" y="1220" type="line"/>
+      <point x="1065" y="0" type="line"/>
+      <point x="814" y="0" type="line"/>
+      <point x="800" y="113" type="line"/>
+      <point x="780" y="88"/>
+      <point x="733" y="46"/>
+      <point x="707" y="30" type="qcurve" smooth="yes"/>
+      <point x="668" y="6"/>
+      <point x="575" y="-20"/>
+      <point x="520" y="-20" type="qcurve" smooth="yes"/>
+      <point x="421" y="-20"/>
+      <point x="264" y="63"/>
+      <point x="210" y="136" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="155" y="209"/>
+      <point x="97" y="410"/>
+      <point x="97" y="528" type="qcurve" smooth="yes"/>
+      <point x="97" y="549" type="line" smooth="yes"/>
+      <point x="97" y="672"/>
+      <point x="154" y="876"/>
+      <point x="209" y="949" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="264" y="1022"/>
+      <point x="421" y="1102"/>
+      <point x="522" y="1102" type="qcurve" smooth="yes"/>
+      <point x="578" y="1102"/>
+      <point x="673" y="1075"/>
+      <point x="713" y="1049" type="qcurve" smooth="yes"/>
+      <point x="732" y="1036"/>
+      <point x="769" y="1004"/>
+      <point x="786" y="985" type="qcurve"/>
+      <point x="786" y="1220" type="line"/>
+      <point x="542" y="1220" type="line"/>
+      <point x="542" y="1400" type="line"/>
+      <point x="786" y="1400" type="line"/>
+      <point x="786" y="1536" type="line"/>
+      <point x="1065" y="1536" type="line"/>
+      <point x="1065" y="1400" type="line"/>
+      <point x="1234" y="1400" type="line"/>
     </contour>
     <contour>
-      <point x="390" y="528" type="line" smooth="yes"/>
-      <point x="390" y="460"/>
-      <point x="413" y="343"/>
-      <point x="439" y="300" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="465" y="256"/>
-      <point x="547" y="206"/>
-      <point x="606" y="206" type="qcurve" smooth="yes"/>
-      <point x="643" y="206"/>
-      <point x="704" y="223"/>
-      <point x="728" y="238" type="qcurve" smooth="yes"/>
-      <point x="751" y="253"/>
-      <point x="787" y="296"/>
-      <point x="801" y="322" type="qcurve"/>
-      <point x="801" y="760" type="line"/>
-      <point x="786" y="789"/>
-      <point x="746" y="835"/>
-      <point x="719" y="850" type="qcurve" smooth="yes"/>
-      <point x="697" y="862"/>
-      <point x="641" y="876"/>
-      <point x="608" y="876" type="qcurve" smooth="yes"/>
-      <point x="549" y="876"/>
-      <point x="466" y="825"/>
-      <point x="440" y="781" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="414" y="736"/>
-      <point x="390" y="617"/>
-      <point x="390" y="549" type="qcurve" smooth="yes"/>
+      <point x="375" y="528" type="line" smooth="yes"/>
+      <point x="375" y="460"/>
+      <point x="398" y="343"/>
+      <point x="424" y="300" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="450" y="256"/>
+      <point x="532" y="206"/>
+      <point x="591" y="206" type="qcurve" smooth="yes"/>
+      <point x="628" y="206"/>
+      <point x="689" y="223"/>
+      <point x="713" y="238" type="qcurve" smooth="yes"/>
+      <point x="736" y="253"/>
+      <point x="772" y="296"/>
+      <point x="786" y="322" type="qcurve"/>
+      <point x="786" y="760" type="line"/>
+      <point x="771" y="789"/>
+      <point x="731" y="835"/>
+      <point x="704" y="850" type="qcurve" smooth="yes"/>
+      <point x="682" y="862"/>
+      <point x="626" y="876"/>
+      <point x="593" y="876" type="qcurve" smooth="yes"/>
+      <point x="534" y="876"/>
+      <point x="451" y="825"/>
+      <point x="425" y="781" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="399" y="736"/>
+      <point x="375" y="617"/>
+      <point x="375" y="549" type="qcurve" smooth="yes"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Bold.ufo/glyphs/dotbelow.glif
+++ b/sources/RobotoMono-Bold.ufo/glyphs/dotbelow.glif
@@ -1,6 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="dotbelow" format="2">
-  <advance width="1229"/>
   <unicode hex="0323"/>
   <outline>
     <contour>

--- a/sources/RobotoMono-Bold.ufo/glyphs/exclam.glif
+++ b/sources/RobotoMono-Bold.ufo/glyphs/exclam.glif
@@ -4,24 +4,24 @@
   <unicode hex="0021"/>
   <outline>
     <contour>
-      <point x="735" y="509" type="line"/>
-      <point x="482" y="509" type="line"/>
-      <point x="466" y="1456" type="line"/>
-      <point x="751" y="1456" type="line"/>
+      <point x="741" y="509" type="line"/>
+      <point x="488" y="509" type="line"/>
+      <point x="472" y="1456" type="line"/>
+      <point x="757" y="1456" type="line"/>
     </contour>
     <contour>
-      <point x="446" y="136" type="qcurve" smooth="yes"/>
-      <point x="446.0" y="202.0"/>
-      <point x="532.0000000000001" y="290.0"/>
-      <point x="608" y="290" type="qcurve" smooth="yes"/>
-      <point x="682.0" y="290.0"/>
-      <point x="770.0" y="202.0"/>
-      <point x="770" y="136" type="qcurve" smooth="yes"/>
-      <point x="770.0" y="72.00000000000001"/>
-      <point x="682.0" y="-15.0"/>
-      <point x="608" y="-15" type="qcurve" smooth="yes"/>
-      <point x="532.0000000000001" y="-15.0"/>
-      <point x="446.0" y="72.00000000000001"/>
+      <point x="452" y="136" type="qcurve" smooth="yes"/>
+      <point x="452" y="202"/>
+      <point x="538" y="290"/>
+      <point x="614" y="290" type="qcurve" smooth="yes"/>
+      <point x="688" y="290"/>
+      <point x="776" y="202"/>
+      <point x="776" y="136" type="qcurve" smooth="yes"/>
+      <point x="776" y="72"/>
+      <point x="688" y="-15"/>
+      <point x="614" y="-15" type="qcurve" smooth="yes"/>
+      <point x="538" y="-15"/>
+      <point x="452" y="72"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Bold.ufo/glyphs/exclamdbl.glif
+++ b/sources/RobotoMono-Bold.ufo/glyphs/exclamdbl.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="exclamdbl" format="2">
-  <advance width="2458"/>
+  <advance width="1229"/>
   <unicode hex="203C"/>
   <outline>
-    <component base="exclam"/>
-    <component base="exclam" xOffset="1229"/>
+    <component base="exclam" xOffset="-393"/>
+    <component base="exclam" xOffset="407"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Bold.ufo/glyphs/gravecomb.glif
+++ b/sources/RobotoMono-Bold.ufo/glyphs/gravecomb.glif
@@ -1,6 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="gravecomb" format="2">
-  <advance width="1229"/>
   <unicode hex="0300"/>
   <outline>
     <contour>

--- a/sources/RobotoMono-Bold.ufo/glyphs/hbar.glif
+++ b/sources/RobotoMono-Bold.ufo/glyphs/hbar.glif
@@ -1,49 +1,49 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="hbar" format="2">
-  <advance width="1259"/>
+  <advance width="1229"/>
   <unicode hex="0127"/>
   <outline>
     <contour>
-      <point x="703" y="1216" type="line"/>
-      <point x="449" y="1216" type="line"/>
-      <point x="449" y="933" type="line"/>
-      <point x="471" y="966"/>
-      <point x="525" y="1021"/>
-      <point x="555" y="1041" type="qcurve" smooth="yes"/>
-      <point x="598" y="1070"/>
-      <point x="698" y="1102"/>
-      <point x="754" y="1102" type="qcurve" smooth="yes"/>
-      <point x="839" y="1102"/>
-      <point x="981" y="1051"/>
-      <point x="1032" y="997" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="1083" y="943"/>
-      <point x="1140" y="774"/>
-      <point x="1140" y="655" type="qcurve" smooth="yes"/>
-      <point x="1140" y="0" type="line"/>
-      <point x="862" y="0" type="line"/>
-      <point x="862" y="657" type="line" smooth="yes"/>
-      <point x="862" y="715"/>
-      <point x="833" y="799"/>
-      <point x="806" y="825" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="779" y="851"/>
-      <point x="703" y="876"/>
-      <point x="655" y="876" type="qcurve" smooth="yes"/>
-      <point x="624" y="876"/>
-      <point x="570" y="866"/>
-      <point x="547" y="857" type="qcurve" smooth="yes"/>
-      <point x="517" y="845"/>
-      <point x="468" y="806"/>
-      <point x="449" y="781" type="qcurve"/>
-      <point x="449" y="0" type="line"/>
-      <point x="171" y="0" type="line"/>
-      <point x="171" y="1216" type="line"/>
-      <point x="11" y="1216" type="line"/>
-      <point x="11" y="1396" type="line"/>
-      <point x="171" y="1396" type="line"/>
-      <point x="171" y="1536" type="line"/>
-      <point x="449" y="1536" type="line"/>
-      <point x="449" y="1396" type="line"/>
-      <point x="703" y="1396" type="line"/>
+      <point x="688" y="1216" type="line"/>
+      <point x="434" y="1216" type="line"/>
+      <point x="434" y="933" type="line"/>
+      <point x="456" y="966"/>
+      <point x="510" y="1021"/>
+      <point x="540" y="1041" type="qcurve" smooth="yes"/>
+      <point x="583" y="1070"/>
+      <point x="683" y="1102"/>
+      <point x="739" y="1102" type="qcurve" smooth="yes"/>
+      <point x="824" y="1102"/>
+      <point x="966" y="1051"/>
+      <point x="1017" y="997" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="1068" y="943"/>
+      <point x="1125" y="774"/>
+      <point x="1125" y="655" type="qcurve" smooth="yes"/>
+      <point x="1125" y="0" type="line"/>
+      <point x="847" y="0" type="line"/>
+      <point x="847" y="657" type="line" smooth="yes"/>
+      <point x="847" y="715"/>
+      <point x="818" y="799"/>
+      <point x="791" y="825" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="764" y="851"/>
+      <point x="688" y="876"/>
+      <point x="640" y="876" type="qcurve" smooth="yes"/>
+      <point x="609" y="876"/>
+      <point x="555" y="866"/>
+      <point x="532" y="857" type="qcurve" smooth="yes"/>
+      <point x="502" y="845"/>
+      <point x="453" y="806"/>
+      <point x="434" y="781" type="qcurve"/>
+      <point x="434" y="0" type="line"/>
+      <point x="156" y="0" type="line"/>
+      <point x="156" y="1216" type="line"/>
+      <point x="-4" y="1216" type="line"/>
+      <point x="-4" y="1396" type="line"/>
+      <point x="156" y="1396" type="line"/>
+      <point x="156" y="1536" type="line"/>
+      <point x="434" y="1536" type="line"/>
+      <point x="434" y="1396" type="line"/>
+      <point x="688" y="1396" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Bold.ufo/glyphs/hook.glif
+++ b/sources/RobotoMono-Bold.ufo/glyphs/hook.glif
@@ -1,6 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="hook" format="2">
-  <advance width="1229"/>
   <unicode hex="0309"/>
   <outline>
     <contour>

--- a/sources/RobotoMono-Bold.ufo/glyphs/lcaron.glif
+++ b/sources/RobotoMono-Bold.ufo/glyphs/lcaron.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="lcaron" format="2">
-  <advance width="1379"/>
+  <advance width="1229"/>
   <unicode hex="013E"/>
   <outline>
-    <component base="l"/>
-    <component base="quoteright" xOffset="499" yOffset="-19"/>
+    <component base="l" xOffset="-70"/>
+    <component base="quoteright" xOffset="429" yOffset="-19"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Bold.ufo/glyphs/ldot.glif
+++ b/sources/RobotoMono-Bold.ufo/glyphs/ldot.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ldot" format="2">
-  <advance width="1449"/>
+  <advance width="1229"/>
   <unicode hex="0140"/>
   <outline>
-    <component base="l"/>
-    <component base="dotaccent" xOffset="424" yOffset="-551"/>
+    <component base="l" xOffset="-70"/>
+    <component base="dotaccent" xOffset="354" yOffset="-551"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Bold.ufo/glyphs/tcaron.glif
+++ b/sources/RobotoMono-Bold.ufo/glyphs/tcaron.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="tcaron" format="2">
-  <advance width="1269"/>
+  <advance width="1229"/>
   <unicode hex="0165"/>
   <outline>
-    <component base="t"/>
-    <component base="quoteright" xOffset="454" yOffset="163"/>
+    <component base="t" xOffset="-23" yOffset="-3"/>
+    <component base="quoteright" xOffset="431" yOffset="160"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Bold.ufo/glyphs/tildecomb.glif
+++ b/sources/RobotoMono-Bold.ufo/glyphs/tildecomb.glif
@@ -1,6 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="tildecomb" format="2">
-  <advance width="1229"/>
   <unicode hex="0303"/>
   <outline>
     <component base="tilde" xOffset="-1041"/>

--- a/sources/RobotoMono-Bold.ufo/glyphs/uni030F_.glif
+++ b/sources/RobotoMono-Bold.ufo/glyphs/uni030F_.glif
@@ -1,6 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni030F" format="2">
-  <advance width="1229"/>
   <unicode hex="030F"/>
   <outline>
     <contour>

--- a/sources/RobotoMono-Bold.ufo/glyphs/uni0483.glif
+++ b/sources/RobotoMono-Bold.ufo/glyphs/uni0483.glif
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni0483" format="2">
+  <advance width="1229"/>
   <unicode hex="0483"/>
   <outline>
     <contour>

--- a/sources/RobotoMono-Bold.ufo/glyphs/uni0484.glif
+++ b/sources/RobotoMono-Bold.ufo/glyphs/uni0484.glif
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni0484" format="2">
+  <advance width="1229"/>
   <unicode hex="0484"/>
   <outline>
     <contour>

--- a/sources/RobotoMono-Bold.ufo/glyphs/uni0485.glif
+++ b/sources/RobotoMono-Bold.ufo/glyphs/uni0485.glif
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni0485" format="2">
+  <advance width="1229"/>
   <unicode hex="0485"/>
   <outline>
     <contour>

--- a/sources/RobotoMono-Bold.ufo/glyphs/uni0486.glif
+++ b/sources/RobotoMono-Bold.ufo/glyphs/uni0486.glif
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni0486" format="2">
+  <advance width="1229"/>
   <unicode hex="0486"/>
   <outline>
     <contour>

--- a/sources/RobotoMono-Bold.ufo/glyphs/uni0488.glif
+++ b/sources/RobotoMono-Bold.ufo/glyphs/uni0488.glif
@@ -1,182 +1,183 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni0488" format="2">
+  <advance width="1229"/>
   <unicode hex="0488"/>
   <outline>
     <contour>
-      <point x="-660" y="1267" type="line"/>
-      <point x="-660" y="1308"/>
-      <point x="-631" y="1377"/>
-      <point x="-604.0" y="1402.0" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="-577" y="1427"/>
-      <point x="-499" y="1455"/>
-      <point x="-450" y="1455" type="qcurve" smooth="yes"/>
-      <point x="-401" y="1455"/>
-      <point x="-323" y="1427"/>
-      <point x="-295.5" y="1402.0" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="-268" y="1377"/>
-      <point x="-239" y="1308"/>
-      <point x="-239" y="1267" type="qcurve"/>
-      <point x="-351" y="1267" type="line"/>
-      <point x="-351.0" y="1307.7128482353085"/>
-      <point x="-396.929225287352" y="1368.0"/>
-      <point x="-450" y="1368" type="qcurve" smooth="yes"/>
-      <point x="-504.96234511766664" y="1368.0"/>
-      <point x="-547.0" y="1306.311684972332"/>
-      <point x="-547" y="1267" type="qcurve"/>
+      <point x="395" y="1267" type="line"/>
+      <point x="395" y="1308"/>
+      <point x="424" y="1377"/>
+      <point x="451.0" y="1402.0" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="478" y="1427"/>
+      <point x="556" y="1455"/>
+      <point x="605" y="1455" type="qcurve" smooth="yes"/>
+      <point x="654" y="1455"/>
+      <point x="732" y="1427"/>
+      <point x="759.5" y="1402.0" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="787" y="1377"/>
+      <point x="816" y="1308"/>
+      <point x="816" y="1267" type="qcurve"/>
+      <point x="704" y="1267" type="line"/>
+      <point x="704.0" y="1307.7128482353085"/>
+      <point x="658.070774712648" y="1368.0"/>
+      <point x="605" y="1368" type="qcurve" smooth="yes"/>
+      <point x="550.0376548823333" y="1368.0"/>
+      <point x="508.0" y="1306.311684972332"/>
+      <point x="508" y="1267" type="qcurve"/>
     </contour>
     <contour>
-      <point x="-69" y="990" type="line"/>
-      <point x="-69" y="1031"/>
-      <point x="-40" y="1100"/>
-      <point x="-13.0" y="1125.0" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="14" y="1150"/>
-      <point x="92" y="1178"/>
-      <point x="140" y="1178" type="qcurve" smooth="yes"/>
-      <point x="189" y="1178"/>
-      <point x="268" y="1150"/>
-      <point x="295.5" y="1125.0" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="323" y="1100"/>
-      <point x="352" y="1031"/>
-      <point x="352" y="990" type="qcurve"/>
-      <point x="239" y="990" type="line"/>
-      <point x="239.0" y="1030.0"/>
-      <point x="194.0" y="1091.0"/>
-      <point x="140" y="1091" type="qcurve" smooth="yes"/>
-      <point x="87.0732972940988" y="1091.0"/>
-      <point x="44.0" y="1029.311684972332"/>
-      <point x="44" y="990" type="qcurve"/>
+      <point x="986" y="990" type="line"/>
+      <point x="986" y="1031"/>
+      <point x="1015" y="1100"/>
+      <point x="1042.0" y="1125.0" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="1069" y="1150"/>
+      <point x="1147" y="1178"/>
+      <point x="1195" y="1178" type="qcurve" smooth="yes"/>
+      <point x="1244" y="1178"/>
+      <point x="1323" y="1150"/>
+      <point x="1350.5" y="1125.0" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="1378" y="1100"/>
+      <point x="1407" y="1031"/>
+      <point x="1407" y="990" type="qcurve"/>
+      <point x="1294" y="990" type="line"/>
+      <point x="1294.0" y="1030.0"/>
+      <point x="1249.0" y="1091.0"/>
+      <point x="1195" y="1091" type="qcurve" smooth="yes"/>
+      <point x="1142.0732972940987" y="1091.0"/>
+      <point x="1099.0" y="1029.311684972332"/>
+      <point x="1099" y="990" type="qcurve"/>
     </contour>
     <contour>
-      <point x="117" y="487" type="line"/>
-      <point x="117" y="528"/>
-      <point x="146" y="597"/>
-      <point x="173.5" y="622.0" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="201" y="647"/>
-      <point x="279" y="675"/>
-      <point x="327" y="675" type="qcurve" smooth="yes"/>
-      <point x="376" y="675"/>
-      <point x="454" y="647"/>
-      <point x="481.5" y="622.0" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="509" y="597"/>
-      <point x="538" y="528"/>
-      <point x="538" y="487" type="qcurve"/>
-      <point x="426" y="487" type="line"/>
-      <point x="426.0" y="526.9999999999999"/>
-      <point x="381.0" y="588.0"/>
-      <point x="327" y="588" type="qcurve" smooth="yes"/>
-      <point x="274.0732972940988" y="588.0"/>
-      <point x="230.0" y="526.3116849723317"/>
-      <point x="230" y="487" type="qcurve"/>
+      <point x="1172" y="487" type="line"/>
+      <point x="1172" y="528"/>
+      <point x="1201" y="597"/>
+      <point x="1228.5" y="622.0" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="1256" y="647"/>
+      <point x="1334" y="675"/>
+      <point x="1382" y="675" type="qcurve" smooth="yes"/>
+      <point x="1431" y="675"/>
+      <point x="1509" y="647"/>
+      <point x="1536.5" y="622.0" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="1564" y="597"/>
+      <point x="1593" y="528"/>
+      <point x="1593" y="487" type="qcurve"/>
+      <point x="1481" y="487" type="line"/>
+      <point x="1481.0" y="526.9999999999999"/>
+      <point x="1436.0" y="588.0"/>
+      <point x="1382" y="588" type="qcurve" smooth="yes"/>
+      <point x="1329.0732972940987" y="588.0"/>
+      <point x="1285.0" y="526.3116849723317"/>
+      <point x="1285" y="487" type="qcurve"/>
     </contour>
     <contour>
-      <point x="-79" y="-32" type="line"/>
-      <point x="-79" y="9"/>
-      <point x="-50" y="78"/>
-      <point x="-23.0" y="103.0" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="4" y="128"/>
-      <point x="82" y="156"/>
-      <point x="130" y="156" type="qcurve" smooth="yes"/>
-      <point x="179" y="156"/>
-      <point x="257" y="128"/>
-      <point x="284.5" y="103.0" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="312" y="78"/>
-      <point x="341" y="9"/>
-      <point x="341" y="-32" type="qcurve"/>
-      <point x="229" y="-32" type="line"/>
-      <point x="229.0" y="8.0"/>
-      <point x="184.0" y="69.0"/>
-      <point x="130" y="69" type="qcurve" smooth="yes"/>
-      <point x="77.07329729409881" y="69.0"/>
-      <point x="33.0" y="7.311684972331868"/>
-      <point x="33" y="-32" type="qcurve"/>
+      <point x="976" y="-32" type="line"/>
+      <point x="976" y="9"/>
+      <point x="1005" y="78"/>
+      <point x="1032.0" y="103.0" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="1059" y="128"/>
+      <point x="1137" y="156"/>
+      <point x="1185" y="156" type="qcurve" smooth="yes"/>
+      <point x="1234" y="156"/>
+      <point x="1312" y="128"/>
+      <point x="1339.5" y="103.0" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="1367" y="78"/>
+      <point x="1396" y="9"/>
+      <point x="1396" y="-32" type="qcurve"/>
+      <point x="1284" y="-32" type="line"/>
+      <point x="1284.0" y="8.0"/>
+      <point x="1239.0" y="69.0"/>
+      <point x="1185" y="69" type="qcurve" smooth="yes"/>
+      <point x="1132.0732972940987" y="69.0"/>
+      <point x="1088.0" y="7.311684972331868"/>
+      <point x="1088" y="-32" type="qcurve"/>
     </contour>
     <contour>
-      <point x="-655" y="-316" type="line"/>
-      <point x="-655" y="-275"/>
-      <point x="-626" y="-206"/>
-      <point x="-599.0" y="-181.0" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="-572" y="-156"/>
-      <point x="-494" y="-128"/>
-      <point x="-445" y="-128" type="qcurve" smooth="yes"/>
-      <point x="-396" y="-128"/>
-      <point x="-318" y="-156"/>
-      <point x="-290.5" y="-181.0" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="-263" y="-206"/>
-      <point x="-234" y="-275"/>
-      <point x="-234" y="-316" type="qcurve"/>
-      <point x="-346" y="-316" type="line"/>
-      <point x="-346.0" y="-275.2871517646914"/>
-      <point x="-391.929225287352" y="-215.0"/>
-      <point x="-445" y="-215" type="qcurve" smooth="yes"/>
-      <point x="-497.9267027059012" y="-215.0"/>
-      <point x="-542.0" y="-276.6883150276682"/>
-      <point x="-542" y="-316" type="qcurve"/>
+      <point x="400" y="-316" type="line"/>
+      <point x="400" y="-275"/>
+      <point x="429" y="-206"/>
+      <point x="456.0" y="-181.0" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="483" y="-156"/>
+      <point x="561" y="-128"/>
+      <point x="610" y="-128" type="qcurve" smooth="yes"/>
+      <point x="659" y="-128"/>
+      <point x="737" y="-156"/>
+      <point x="764.5" y="-181.0" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="792" y="-206"/>
+      <point x="821" y="-275"/>
+      <point x="821" y="-316" type="qcurve"/>
+      <point x="709" y="-316" type="line"/>
+      <point x="709.0" y="-275.2871517646914"/>
+      <point x="663.070774712648" y="-215.0"/>
+      <point x="610" y="-215" type="qcurve" smooth="yes"/>
+      <point x="557.0732972940988" y="-215.0"/>
+      <point x="513.0" y="-276.6883150276682"/>
+      <point x="513" y="-316" type="qcurve"/>
     </contour>
     <contour>
-      <point x="-1233" y="990" type="line"/>
-      <point x="-1233" y="1031"/>
-      <point x="-1204" y="1100"/>
-      <point x="-1176.5" y="1125.0" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="-1149" y="1150"/>
-      <point x="-1071" y="1178"/>
-      <point x="-1022" y="1178" type="qcurve" smooth="yes"/>
-      <point x="-973" y="1178"/>
-      <point x="-895" y="1150"/>
-      <point x="-867.5" y="1125.0" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="-840" y="1100"/>
-      <point x="-811" y="1031"/>
-      <point x="-811" y="990" type="qcurve"/>
-      <point x="-923" y="990" type="line"/>
-      <point x="-923.0" y="1030.7128482353085"/>
-      <point x="-968.9292252873521" y="1091.0"/>
-      <point x="-1022" y="1091" type="qcurve" smooth="yes"/>
-      <point x="-1076.9623451176667" y="1091.0"/>
-      <point x="-1119.0" y="1029.311684972332"/>
-      <point x="-1119" y="990" type="qcurve"/>
+      <point x="-178" y="990" type="line"/>
+      <point x="-178" y="1031"/>
+      <point x="-149" y="1100"/>
+      <point x="-121.5" y="1125.0" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="-94" y="1150"/>
+      <point x="-16" y="1178"/>
+      <point x="33" y="1178" type="qcurve" smooth="yes"/>
+      <point x="82" y="1178"/>
+      <point x="160" y="1150"/>
+      <point x="187.5" y="1125.0" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="215" y="1100"/>
+      <point x="244" y="1031"/>
+      <point x="244" y="990" type="qcurve"/>
+      <point x="132" y="990" type="line"/>
+      <point x="132.0" y="1030.7128482353085"/>
+      <point x="86.0707747126479" y="1091.0"/>
+      <point x="33" y="1091" type="qcurve" smooth="yes"/>
+      <point x="-21.9623451176667" y="1091.0"/>
+      <point x="-64.0" y="1029.311684972332"/>
+      <point x="-64" y="990" type="qcurve"/>
     </contour>
     <contour>
-      <point x="-1409" y="487" type="line"/>
-      <point x="-1409" y="528"/>
-      <point x="-1380" y="597"/>
-      <point x="-1352.5" y="622.0" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="-1325" y="647"/>
-      <point x="-1247" y="675"/>
-      <point x="-1199" y="675" type="qcurve" smooth="yes"/>
-      <point x="-1150" y="675"/>
-      <point x="-1072" y="647"/>
-      <point x="-1044.5" y="622.0" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="-1017" y="597"/>
-      <point x="-988" y="528"/>
-      <point x="-988" y="487" type="qcurve"/>
-      <point x="-1100" y="487" type="line"/>
-      <point x="-1100.0" y="526.9999999999999"/>
-      <point x="-1145.0" y="588.0"/>
-      <point x="-1199" y="588" type="qcurve" smooth="yes"/>
-      <point x="-1251.926702705901" y="588.0"/>
-      <point x="-1296.0" y="526.3116849723318"/>
-      <point x="-1296" y="487" type="qcurve"/>
+      <point x="-354" y="487" type="line"/>
+      <point x="-354" y="528"/>
+      <point x="-325" y="597"/>
+      <point x="-297.5" y="622.0" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="-270" y="647"/>
+      <point x="-192" y="675"/>
+      <point x="-144" y="675" type="qcurve" smooth="yes"/>
+      <point x="-95" y="675"/>
+      <point x="-17" y="647"/>
+      <point x="10.5" y="622.0" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="38" y="597"/>
+      <point x="67" y="528"/>
+      <point x="67" y="487" type="qcurve"/>
+      <point x="-45" y="487" type="line"/>
+      <point x="-45.0" y="526.9999999999999"/>
+      <point x="-90.0" y="588.0"/>
+      <point x="-144" y="588" type="qcurve" smooth="yes"/>
+      <point x="-196.9267027059011" y="588.0"/>
+      <point x="-241.0" y="526.3116849723318"/>
+      <point x="-241" y="487" type="qcurve"/>
     </contour>
     <contour>
-      <point x="-1243" y="-32" type="line"/>
-      <point x="-1243" y="9"/>
-      <point x="-1214" y="78"/>
-      <point x="-1186.5" y="103.0" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="-1159" y="128"/>
-      <point x="-1081" y="156"/>
-      <point x="-1033" y="156" type="qcurve" smooth="yes"/>
-      <point x="-984" y="156"/>
-      <point x="-905" y="128"/>
-      <point x="-877.5" y="103.0" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="-850" y="78"/>
-      <point x="-821" y="9"/>
-      <point x="-821" y="-32" type="qcurve"/>
-      <point x="-934" y="-32" type="line"/>
-      <point x="-934.0" y="8.000000000000007"/>
-      <point x="-979.0000000000001" y="69.0"/>
-      <point x="-1033" y="69" type="qcurve" smooth="yes"/>
-      <point x="-1085.926702705901" y="69.0"/>
-      <point x="-1129.0" y="7.3116849723319035"/>
-      <point x="-1129" y="-32" type="qcurve"/>
+      <point x="-188" y="-32" type="line"/>
+      <point x="-188" y="9"/>
+      <point x="-159" y="78"/>
+      <point x="-131.5" y="103.0" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="-104" y="128"/>
+      <point x="-26" y="156"/>
+      <point x="22" y="156" type="qcurve" smooth="yes"/>
+      <point x="71" y="156"/>
+      <point x="150" y="128"/>
+      <point x="177.5" y="103.0" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="205" y="78"/>
+      <point x="234" y="9"/>
+      <point x="234" y="-32" type="qcurve"/>
+      <point x="121" y="-32" type="line"/>
+      <point x="121.0" y="8.000000000000007"/>
+      <point x="75.99999999999989" y="69.0"/>
+      <point x="22" y="69" type="qcurve" smooth="yes"/>
+      <point x="-30.926702705901107" y="69.0"/>
+      <point x="-74.0" y="7.3116849723319035"/>
+      <point x="-74" y="-32" type="qcurve"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Bold.ufo/glyphs/uni0489.glif
+++ b/sources/RobotoMono-Bold.ufo/glyphs/uni0489.glif
@@ -1,62 +1,63 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni0489" format="2">
+  <advance width="1229"/>
   <unicode hex="0489"/>
   <outline>
     <contour>
-      <point x="-563" y="-60" type="line"/>
-      <point x="-552" y="-74" type="line"/>
-      <point x="-674" y="-413" type="line"/>
-      <point x="-770" y="-413" type="line"/>
-      <point x="-700" y="-60" type="line"/>
+      <point x="724" y="-60" type="line"/>
+      <point x="735" y="-74" type="line"/>
+      <point x="613" y="-413" type="line"/>
+      <point x="517" y="-413" type="line"/>
+      <point x="587" y="-60" type="line"/>
     </contour>
     <contour>
-      <point x="-758" y="1126" type="line"/>
-      <point x="-770" y="1140" type="line"/>
-      <point x="-648" y="1478" type="line"/>
-      <point x="-552" y="1478" type="line"/>
-      <point x="-622" y="1126" type="line"/>
+      <point x="529" y="1126" type="line"/>
+      <point x="517" y="1140" type="line"/>
+      <point x="639" y="1478" type="line"/>
+      <point x="735" y="1478" type="line"/>
+      <point x="665" y="1126" type="line"/>
     </contour>
     <contour>
-      <point x="-80" y="631" type="line"/>
-      <point x="-67" y="643" type="line"/>
-      <point x="265" y="519" type="line"/>
-      <point x="265" y="421" type="line"/>
-      <point x="-80" y="492" type="line"/>
+      <point x="1207" y="631" type="line"/>
+      <point x="1220" y="643" type="line"/>
+      <point x="1552" y="519" type="line"/>
+      <point x="1552" y="421" type="line"/>
+      <point x="1207" y="492" type="line"/>
     </contour>
     <contour>
-      <point x="-1244" y="433" type="line"/>
-      <point x="-1257" y="421" type="line"/>
-      <point x="-1590" y="545" type="line"/>
-      <point x="-1590" y="643" type="line"/>
-      <point x="-1244" y="572" type="line"/>
+      <point x="43" y="433" type="line"/>
+      <point x="30" y="421" type="line"/>
+      <point x="-303" y="545" type="line"/>
+      <point x="-303" y="643" type="line"/>
+      <point x="43" y="572" type="line"/>
     </contour>
     <contour>
-      <point x="-320" y="1002" type="line"/>
-      <point x="-318" y="1018" type="line"/>
-      <point x="2" y="1171" type="line"/>
-      <point x="70" y="1103" type="line"/>
-      <point x="-223" y="903" type="line"/>
+      <point x="967" y="1002" type="line"/>
+      <point x="969" y="1018" type="line"/>
+      <point x="1289" y="1171" type="line"/>
+      <point x="1357" y="1103" type="line"/>
+      <point x="1064" y="903" type="line"/>
     </contour>
     <contour>
-      <point x="-1004" y="21" type="line"/>
-      <point x="-1006" y="4" type="line"/>
-      <point x="-1326" y="-149" type="line"/>
-      <point x="-1395" y="-80" type="line"/>
-      <point x="-1101" y="120" type="line"/>
+      <point x="283" y="21" type="line"/>
+      <point x="281" y="4" type="line"/>
+      <point x="-39" y="-149" type="line"/>
+      <point x="-108" y="-80" type="line"/>
+      <point x="186" y="120" type="line"/>
     </contour>
     <contour>
-      <point x="-1144" y="860" type="line"/>
-      <point x="-1161" y="862" type="line"/>
-      <point x="-1309" y="1188" type="line"/>
-      <point x="-1244" y="1257" type="line"/>
-      <point x="-1046" y="958" type="line"/>
+      <point x="143" y="860" type="line"/>
+      <point x="126" y="862" type="line"/>
+      <point x="-22" y="1188" type="line"/>
+      <point x="43" y="1257" type="line"/>
+      <point x="241" y="958" type="line"/>
     </contour>
     <contour>
-      <point x="-182" y="161" type="line"/>
-      <point x="-165" y="159" type="line"/>
-      <point x="-16" y="-166" type="line"/>
-      <point x="-82" y="-237" type="line"/>
-      <point x="-279" y="62" type="line"/>
+      <point x="1105" y="161" type="line"/>
+      <point x="1122" y="159" type="line"/>
+      <point x="1271" y="-166" type="line"/>
+      <point x="1205" y="-237" type="line"/>
+      <point x="1008" y="62" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Bold.ufo/glyphs/uni049E_.glif
+++ b/sources/RobotoMono-Bold.ufo/glyphs/uni049E_.glif
@@ -1,30 +1,30 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni049E" format="2">
-  <advance width="1249"/>
+  <advance width="1229"/>
   <unicode hex="049E"/>
   <outline>
     <contour>
-      <point x="569" y="598" type="line"/>
-      <point x="452" y="598" type="line"/>
-      <point x="452" y="0" type="line"/>
-      <point x="171" y="0" type="line"/>
-      <point x="171" y="1137" type="line"/>
-      <point x="-19" y="1137" type="line"/>
-      <point x="-19" y="1317" type="line"/>
-      <point x="171" y="1317" type="line"/>
-      <point x="171" y="1456" type="line"/>
-      <point x="452" y="1456" type="line"/>
-      <point x="452" y="1317" type="line"/>
-      <point x="673" y="1317" type="line"/>
-      <point x="673" y="1137" type="line"/>
-      <point x="452" y="1137" type="line"/>
-      <point x="452" y="815" type="line"/>
-      <point x="521" y="815" type="line"/>
-      <point x="902" y="1456" type="line"/>
-      <point x="1227" y="1456" type="line"/>
-      <point x="793" y="755" type="line"/>
-      <point x="1244" y="0" type="line"/>
-      <point x="918" y="0" type="line"/>
+      <point x="559" y="598" type="line"/>
+      <point x="442" y="598" type="line"/>
+      <point x="442" y="0" type="line"/>
+      <point x="161" y="0" type="line"/>
+      <point x="161" y="1137" type="line"/>
+      <point x="-29" y="1137" type="line"/>
+      <point x="-29" y="1317" type="line"/>
+      <point x="161" y="1317" type="line"/>
+      <point x="161" y="1456" type="line"/>
+      <point x="442" y="1456" type="line"/>
+      <point x="442" y="1317" type="line"/>
+      <point x="663" y="1317" type="line"/>
+      <point x="663" y="1137" type="line"/>
+      <point x="442" y="1137" type="line"/>
+      <point x="442" y="815" type="line"/>
+      <point x="511" y="815" type="line"/>
+      <point x="892" y="1456" type="line"/>
+      <point x="1217" y="1456" type="line"/>
+      <point x="783" y="755" type="line"/>
+      <point x="1234" y="0" type="line"/>
+      <point x="908" y="0" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Bold.ufo/glyphs/uni049F_.glif
+++ b/sources/RobotoMono-Bold.ufo/glyphs/uni049F_.glif
@@ -1,30 +1,30 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni049F" format="2">
-  <advance width="1249"/>
+  <advance width="1229"/>
   <unicode hex="049F"/>
   <outline>
     <contour>
-      <point x="164" y="0" type="line"/>
-      <point x="164" y="1208" type="line"/>
-      <point x="-35" y="1208" type="line"/>
-      <point x="-35" y="1388" type="line"/>
-      <point x="164" y="1388" type="line"/>
-      <point x="164" y="1536" type="line"/>
-      <point x="442" y="1536" type="line"/>
-      <point x="442" y="1388" type="line"/>
-      <point x="657" y="1388" type="line"/>
-      <point x="657" y="1208" type="line"/>
-      <point x="442" y="1208" type="line"/>
-      <point x="442" y="658" type="line"/>
-      <point x="526" y="754" type="line"/>
-      <point x="825" y="1082" type="line"/>
-      <point x="1159" y="1082" type="line"/>
-      <point x="751" y="631" type="line"/>
-      <point x="1216" y="0" type="line"/>
-      <point x="875" y="0" type="line"/>
-      <point x="568" y="447" type="line"/>
-      <point x="442" y="330" type="line"/>
-      <point x="442" y="0" type="line"/>
+      <point x="154" y="0" type="line"/>
+      <point x="154" y="1208" type="line"/>
+      <point x="-45" y="1208" type="line"/>
+      <point x="-45" y="1388" type="line"/>
+      <point x="154" y="1388" type="line"/>
+      <point x="154" y="1536" type="line"/>
+      <point x="432" y="1536" type="line"/>
+      <point x="432" y="1388" type="line"/>
+      <point x="647" y="1388" type="line"/>
+      <point x="647" y="1208" type="line"/>
+      <point x="432" y="1208" type="line"/>
+      <point x="432" y="658" type="line"/>
+      <point x="516" y="754" type="line"/>
+      <point x="815" y="1082" type="line"/>
+      <point x="1149" y="1082" type="line"/>
+      <point x="741" y="631" type="line"/>
+      <point x="1206" y="0" type="line"/>
+      <point x="865" y="0" type="line"/>
+      <point x="558" y="447" type="line"/>
+      <point x="432" y="330" type="line"/>
+      <point x="432" y="0" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Bold.ufo/glyphs/uni20A_B_.glif
+++ b/sources/RobotoMono-Bold.ufo/glyphs/uni20A_B_.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni20AB" format="2">
-  <advance width="1259"/>
+  <advance width="1229"/>
   <unicode hex="20AB"/>
   <outline>
-    <component base="d"/>
-    <component base="crossbar" xOffset="256" yOffset="572"/>
-    <component base="underscore" xOffset="50" yOffset="-105"/>
+    <component base="d" xOffset="-15"/>
+    <component base="crossbar" xOffset="241" yOffset="572"/>
+    <component base="underscore" xOffset="35" yOffset="-105"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Bold.ufo/lib.plist
+++ b/sources/RobotoMono-Bold.ufo/lib.plist
@@ -2,6 +2,17 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
   <dict>
+    <key>com.defcon.sortDescriptor</key>
+    <array>
+      <dict>
+        <key>allowPseudoUnicode</key>
+        <integer>0</integer>
+        <key>ascending</key>
+        <string>Amstelvar DB Best</string>
+        <key>type</key>
+        <string>characterSet</string>
+      </dict>
+    </array>
     <key>com.typemytype.robofont.binarySource</key>
     <string>/Users/pichotta/Downloads/Roboto_Mono/RobotoMono-Bold.ttf</string>
     <key>com.typemytype.robofont.fontIdentifier</key>
@@ -10,41 +21,8 @@
     <string>qcurve</string>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
       <string>NULL</string>
-      <string>nonmarkingreturn</string>
       <string>space</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
       <string>B</string>
       <string>C</string>
@@ -71,12 +49,6 @@
       <string>X</string>
       <string>Y</string>
       <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
       <string>a</string>
       <string>b</string>
       <string>c</string>
@@ -103,84 +75,329 @@
       <string>x</string>
       <string>y</string>
       <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemotleft</string>
-      <string>logicalnot</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
+      <string>onesuperior</string>
       <string>twosuperior</string>
       <string>threesuperior</string>
-      <string>acute</string>
-      <string>mu</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
+      <string>ordfeminine</string>
       <string>ordmasculine</string>
-      <string>guillemotright</string>
-      <string>onequarter</string>
       <string>onehalf</string>
+      <string>onequarter</string>
       <string>threequarters</string>
-      <string>questiondown</string>
       <string>AE</string>
-      <string>multiply</string>
-      <string>Oslash</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
       <string>ae</string>
+      <string>OE</string>
+      <string>oe</string>
       <string>eth</string>
-      <string>divide</string>
-      <string>oslash</string>
+      <string>Thorn</string>
       <string>thorn</string>
+      <string>kgreenlandic</string>
+      <string>germandbls</string>
+      <string>schwa</string>
+      <string>dollar</string>
+      <string>cent</string>
+      <string>sterling</string>
+      <string>yen</string>
+      <string>florin</string>
+      <string>franc</string>
+      <string>lira</string>
+      <string>peseta</string>
+      <string>currency</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>comma</string>
+      <string>period</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>ellipsis</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>underscore</string>
+      <string>hyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>quotesingle</string>
+      <string>quotedbl</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quotedblbase</string>
+      <string>minute</string>
+      <string>second</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>plusminus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>approxequal</string>
+      <string>less</string>
+      <string>greater</string>
+      <string>lessequal</string>
+      <string>greaterequal</string>
+      <string>logicalnot</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>fraction</string>
+      <string>percent</string>
+      <string>perthousand</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>dagger</string>
+      <string>daggerdbl</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>ampersand</string>
+      <string>at</string>
+      <string>section</string>
+      <string>paragraph</string>
+      <string>asciicircum</string>
+      <string>asciitilde</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Acircumflex</string>
+      <string>Adieresis</string>
+      <string>Agrave</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Aringacute</string>
+      <string>Atilde</string>
+      <string>AEacute</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Ccircumflex</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Eacute</string>
+      <string>Ebreve</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Egrave</string>
+      <string>Emacron</string>
+      <string>Eng</string>
+      <string>Eogonek</string>
+      <string>Eth</string>
+      <string>Gbreve</string>
+      <string>Gcircumflex</string>
+      <string>Gcommaaccent</string>
       <string>Hbar</string>
+      <string>Hcircumflex</string>
+      <string>Iacute</string>
+      <string>Ibreve</string>
+      <string>Icircumflex</string>
+      <string>Idieresis</string>
+      <string>Idotaccent</string>
+      <string>Igrave</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>Jcircumflex</string>
+      <string>Kcommaaccent</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ntilde</string>
+      <string>Oacute</string>
+      <string>Obreve</string>
+      <string>Ocircumflex</string>
+      <string>Odieresis</string>
+      <string>Ograve</string>
+      <string>Ohorn</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
+      <string>Oslash</string>
+      <string>Oslashacute</string>
+      <string>Otilde</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scircumflex</string>
+      <string>Tbar</string>
+      <string>Tcaron</string>
+      <string>Uacute</string>
+      <string>Ubreve</string>
+      <string>Ucircumflex</string>
+      <string>Udieresis</string>
+      <string>Ugrave</string>
+      <string>Uhorn</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>Yacute</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ygrave</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>aacute</string>
+      <string>abreve</string>
+      <string>acircumflex</string>
+      <string>adieresis</string>
+      <string>agrave</string>
+      <string>amacron</string>
+      <string>aogonek</string>
+      <string>aring</string>
+      <string>aringacute</string>
+      <string>atilde</string>
+      <string>aeacute</string>
+      <string>cacute</string>
+      <string>ccaron</string>
+      <string>ccedilla</string>
+      <string>ccircumflex</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>eacute</string>
+      <string>ebreve</string>
+      <string>ecaron</string>
+      <string>ecircumflex</string>
+      <string>edieresis</string>
+      <string>edotaccent</string>
+      <string>egrave</string>
+      <string>emacron</string>
+      <string>eng</string>
+      <string>eogonek</string>
+      <string>gbreve</string>
+      <string>gcircumflex</string>
+      <string>gcommaaccent</string>
+      <string>hbar</string>
+      <string>hcircumflex</string>
+      <string>iacute</string>
+      <string>ibreve</string>
+      <string>icircumflex</string>
+      <string>idieresis</string>
+      <string>igrave</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>jcircumflex</string>
+      <string>kcommaaccent</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ntilde</string>
+      <string>oacute</string>
+      <string>obreve</string>
+      <string>ocircumflex</string>
+      <string>odieresis</string>
+      <string>ograve</string>
+      <string>ohorn</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
+      <string>oslash</string>
+      <string>oslashacute</string>
+      <string>otilde</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scircumflex</string>
+      <string>tbar</string>
+      <string>tcaron</string>
+      <string>uacute</string>
+      <string>ubreve</string>
+      <string>ucircumflex</string>
+      <string>udieresis</string>
+      <string>ugrave</string>
+      <string>uhorn</string>
+      <string>uhungarumlaut</string>
+      <string>umacron</string>
+      <string>uogonek</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>wacute</string>
+      <string>wcircumflex</string>
+      <string>wdieresis</string>
+      <string>wgrave</string>
+      <string>yacute</string>
+      <string>ycircumflex</string>
+      <string>ydieresis</string>
+      <string>ygrave</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>circumflex</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>breve</string>
+      <string>dotaccent</string>
+      <string>dieresis</string>
+      <string>ring</string>
+      <string>hungarumlaut</string>
+      <string>caron</string>
+      <string>dotbelow</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
+      <string>commaaccent</string>
+      <string>.notdef</string>
+      <string>nonmarkingreturn</string>
+      <string>guillemotleft</string>
+      <string>mu</string>
+      <string>guillemotright</string>
       <string>dotlessi</string>
       <string>IJ</string>
       <string>ij</string>
-      <string>kgreenlandic</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Eng</string>
-      <string>eng</string>
-      <string>OE</string>
-      <string>oe</string>
       <string>longs</string>
-      <string>florin</string>
-      <string>Ohorn</string>
-      <string>ohorn</string>
-      <string>Uhorn</string>
-      <string>uhorn</string>
       <string>uni0237</string>
-      <string>schwa</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
       <string>uni02F3</string>
       <string>gravecomb</string>
       <string>acutecomb</string>
       <string>tildecomb</string>
       <string>hook</string>
       <string>uni030F</string>
-      <string>dotbelow</string>
       <string>tonos</string>
       <string>dieresistonos</string>
       <string>anoteleia</string>
@@ -366,34 +583,15 @@
       <string>uni2009</string>
       <string>uni200A</string>
       <string>uni200B</string>
-      <string>endash</string>
-      <string>emdash</string>
       <string>underscoredbl</string>
-      <string>quoteleft</string>
-      <string>quoteright</string>
-      <string>quotesinglbase</string>
       <string>quotereversed</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>quotedblbase</string>
-      <string>dagger</string>
-      <string>daggerdbl</string>
-      <string>bullet</string>
       <string>uni2025</string>
-      <string>ellipsis</string>
-      <string>perthousand</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
       <string>uni2074</string>
       <string>nsuperior</string>
-      <string>lira</string>
-      <string>peseta</string>
       <string>Euro</string>
       <string>uni2105</string>
       <string>uni2113</string>
       <string>uni2116</string>
-      <string>trademark</string>
       <string>estimated</string>
       <string>oneeighth</string>
       <string>threeeighths</string>
@@ -402,16 +600,10 @@
       <string>partialdiff</string>
       <string>product</string>
       <string>summation</string>
-      <string>minus</string>
       <string>radical</string>
       <string>infinity</string>
       <string>integral</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>lessequal</string>
-      <string>greaterequal</string>
       <string>lozenge</string>
-      <string>commaaccent</string>
       <string>uniFEFF</string>
       <string>uniFFFC</string>
       <string>uniFFFD</string>
@@ -466,186 +658,18 @@
       <string>Germandbls.smcp</string>
       <string>nonbreakingspace</string>
       <string>uni00AD</string>
-      <string>Dcroat</string>
-      <string>Eth</string>
-      <string>hbar</string>
-      <string>Tbar</string>
-      <string>tbar</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>Aringacute</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
-      <string>Iacute</string>
-      <string>Icircumflex</string>
-      <string>Idieresis</string>
-      <string>Ntilde</string>
-      <string>Ograve</string>
-      <string>Oacute</string>
-      <string>Ocircumflex</string>
-      <string>Otilde</string>
-      <string>Odieresis</string>
-      <string>Ugrave</string>
-      <string>Uacute</string>
-      <string>Ucircumflex</string>
-      <string>Udieresis</string>
-      <string>Yacute</string>
-      <string>agrave</string>
-      <string>aacute</string>
-      <string>acircumflex</string>
-      <string>atilde</string>
-      <string>adieresis</string>
-      <string>aring</string>
-      <string>aringacute</string>
-      <string>ccedilla</string>
-      <string>egrave</string>
-      <string>eacute</string>
-      <string>ecircumflex</string>
-      <string>edieresis</string>
-      <string>igrave</string>
-      <string>iacute</string>
-      <string>icircumflex</string>
-      <string>idieresis</string>
-      <string>ntilde</string>
-      <string>ograve</string>
-      <string>oacute</string>
-      <string>ocircumflex</string>
-      <string>otilde</string>
-      <string>odieresis</string>
-      <string>ugrave</string>
-      <string>uacute</string>
-      <string>ucircumflex</string>
-      <string>udieresis</string>
-      <string>yacute</string>
-      <string>ydieresis</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Ccircumflex</string>
-      <string>ccircumflex</string>
       <string>uni010A</string>
       <string>uni010B</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Ebreve</string>
-      <string>ebreve</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Gcircumflex</string>
-      <string>gcircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
       <string>uni0120</string>
       <string>uni0121</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Hcircumflex</string>
-      <string>hcircumflex</string>
-      <string>Itilde</string>
-      <string>itilde</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Ibreve</string>
-      <string>ibreve</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Idotaccent</string>
-      <string>Jcircumflex</string>
-      <string>jcircumflex</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
       <string>napostrophe</string>
-      <string>Omacron</string>
-      <string>omacron</string>
-      <string>Obreve</string>
-      <string>obreve</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Rcommaaccent</string>
-      <string>rcommaaccent</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Scircumflex</string>
-      <string>scircumflex</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
       <string>uni0218</string>
       <string>uni0219</string>
-      <string>Scaron</string>
-      <string>scaron</string>
       <string>uni021A</string>
       <string>uni021B</string>
       <string>uni0162</string>
       <string>uni0162.smcp</string>
       <string>uni0163</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Utilde</string>
-      <string>utilde</string>
-      <string>Umacron</string>
-      <string>umacron</string>
-      <string>Ubreve</string>
-      <string>ubreve</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Uhungarumlaut</string>
-      <string>uhungarumlaut</string>
-      <string>Uogonek</string>
-      <string>uogonek</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Ycircumflex</string>
-      <string>ycircumflex</string>
-      <string>Ydieresis</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>AEacute</string>
-      <string>aeacute</string>
-      <string>Oslashacute</string>
-      <string>oslashacute</string>
       <string>Dcroat.smcp</string>
       <string>Eth.smcp</string>
       <string>Tbar.smcp</string>
@@ -807,16 +831,6 @@
       <string>uni0458</string>
       <string>uni045C</string>
       <string>uni045E</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
-      <string>wacute</string>
-      <string>Wdieresis</string>
-      <string>wdieresis</string>
-      <string>Ygrave</string>
-      <string>ygrave</string>
-      <string>minute</string>
-      <string>second</string>
       <string>exclamdbl</string>
       <string>uni01F0</string>
       <string>uni02BC</string>
@@ -973,7 +987,6 @@
       <string>uni1EF7</string>
       <string>uni1EF8</string>
       <string>uni1EF9</string>
-      <string>dcroat</string>
       <string>uni20AB</string>
       <string>uni049A</string>
       <string>uni049B</string>
@@ -1014,9 +1027,7 @@
       <string>uni04FE</string>
       <string>uni04FF</string>
       <string>uni0511</string>
-      <string>franc</string>
       <string>uni2015</string>
-      <string>exclam</string>
     </array>
   </dict>
 </plist>

--- a/sources/RobotoMono-BoldItalic.ufo/glyphs/D_croat.glif
+++ b/sources/RobotoMono-BoldItalic.ufo/glyphs/D_croat.glif
@@ -1,57 +1,57 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Dcroat" format="2">
-  <advance width="1232"/>
+  <advance width="1202"/>
   <unicode hex="0110"/>
   <outline>
     <contour>
-      <point x="47" y="0" type="line"/>
-      <point x="158" y="643" type="line"/>
-      <point x="-19" y="643" type="line"/>
-      <point x="13" y="823" type="line"/>
-      <point x="189" y="823" type="line"/>
-      <point x="299" y="1456" type="line"/>
-      <point x="651" y="1455" type="line" smooth="yes"/>
-      <point x="757" y="1453"/>
-      <point x="927" y="1388"/>
-      <point x="990" y="1333" type="qcurve" smooth="yes"/>
-      <point x="1049.9220586604401" y="1281.6382354339087"/>
-      <point x="1133.9859825149106" y="1137.135149553448"/>
-      <point x="1154" y="1054" type="qcurve" smooth="yes"/>
-      <point x="1169" y="993"/>
-      <point x="1176" y="857"/>
-      <point x="1167" y="787" type="qcurve" smooth="yes"/>
-      <point x="1150" y="667" type="line" smooth="yes"/>
-      <point x="1130" y="530"/>
-      <point x="1012" y="286"/>
-      <point x="921" y="196" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="829" y="105"/>
-      <point x="586" y="-1"/>
-      <point x="441" y="0" type="qcurve" smooth="yes"/>
+      <point x="32" y="0" type="line"/>
+      <point x="143" y="643" type="line"/>
+      <point x="-34" y="643" type="line"/>
+      <point x="-2" y="823" type="line"/>
+      <point x="174" y="823" type="line"/>
+      <point x="284" y="1456" type="line"/>
+      <point x="636" y="1455" type="line" smooth="yes"/>
+      <point x="742" y="1453"/>
+      <point x="912" y="1388"/>
+      <point x="975" y="1333" type="qcurve" smooth="yes"/>
+      <point x="1035" y="1282"/>
+      <point x="1119" y="1137"/>
+      <point x="1139" y="1054" type="qcurve" smooth="yes"/>
+      <point x="1154" y="993"/>
+      <point x="1161" y="857"/>
+      <point x="1152" y="787" type="qcurve" smooth="yes"/>
+      <point x="1135" y="667" type="line" smooth="yes"/>
+      <point x="1115" y="530"/>
+      <point x="997" y="286"/>
+      <point x="906" y="196" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="814" y="105"/>
+      <point x="571" y="-1"/>
+      <point x="426" y="0" type="qcurve" smooth="yes"/>
     </contour>
     <contour>
-      <point x="654" y="643" type="line"/>
-      <point x="434" y="643" type="line"/>
-      <point x="362" y="226" type="line"/>
-      <point x="453" y="224" type="line" smooth="yes"/>
-      <point x="548" y="224"/>
-      <point x="692" y="299"/>
-      <point x="743.0" y="360.5" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="794" y="422"/>
-      <point x="857" y="582"/>
-      <point x="870" y="667" type="qcurve" smooth="yes"/>
-      <point x="887" y="790" type="line" smooth="yes"/>
-      <point x="893" y="838"/>
-      <point x="894" y="939"/>
-      <point x="886.5" y="987.0" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="879" y="1035"/>
-      <point x="844" y="1120"/>
-      <point x="814.5" y="1152.5" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="785" y="1185"/>
-      <point x="699" y="1224"/>
-      <point x="640" y="1227" type="qcurve" smooth="yes"/>
-      <point x="536" y="1228" type="line"/>
-      <point x="465" y="823" type="line"/>
-      <point x="686" y="823" type="line"/>
+      <point x="639" y="643" type="line"/>
+      <point x="419" y="643" type="line"/>
+      <point x="347" y="226" type="line"/>
+      <point x="438" y="224" type="line" smooth="yes"/>
+      <point x="533" y="224"/>
+      <point x="677" y="299"/>
+      <point x="728.0" y="361" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="779" y="422"/>
+      <point x="842" y="582"/>
+      <point x="855" y="667" type="qcurve" smooth="yes"/>
+      <point x="872" y="790" type="line" smooth="yes"/>
+      <point x="878" y="838"/>
+      <point x="879" y="939"/>
+      <point x="872" y="987.0" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="864" y="1035"/>
+      <point x="829" y="1120"/>
+      <point x="800" y="1153" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="770" y="1185"/>
+      <point x="684" y="1224"/>
+      <point x="625" y="1227" type="qcurve" smooth="yes"/>
+      <point x="521" y="1228" type="line"/>
+      <point x="450" y="823" type="line"/>
+      <point x="671" y="823" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/RobotoMono-BoldItalic.ufo/glyphs/E_psilontonos.glif
+++ b/sources/RobotoMono-BoldItalic.ufo/glyphs/E_psilontonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Epsilontonos" format="2">
-  <advance width="1302"/>
+  <advance width="1202"/>
   <unicode hex="0388"/>
   <outline>
-    <component base="E" xOffset="100"/>
-    <component base="tonos" xOffset="-690" yOffset="2"/>
+    <component base="E" xOffset="50"/>
+    <component base="tonos" xOffset="-680" yOffset="2"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-BoldItalic.ufo/glyphs/E_tatonos.glif
+++ b/sources/RobotoMono-BoldItalic.ufo/glyphs/E_tatonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etatonos" format="2">
-  <advance width="1302"/>
+  <advance width="1202"/>
   <unicode hex="0389"/>
   <outline>
-    <component base="H" xOffset="100"/>
-    <component base="tonos" xOffset="-666" yOffset="-2"/>
+    <component base="H" xOffset="50"/>
+    <component base="tonos" xOffset="-696" yOffset="-2"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-BoldItalic.ufo/glyphs/E_th.glif
+++ b/sources/RobotoMono-BoldItalic.ufo/glyphs/E_th.glif
@@ -1,57 +1,57 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Eth" format="2">
-  <advance width="1232"/>
+  <advance width="1202"/>
   <unicode hex="00D0"/>
   <outline>
     <contour>
-      <point x="47" y="0" type="line"/>
-      <point x="158" y="643" type="line"/>
-      <point x="-19" y="643" type="line"/>
-      <point x="13" y="823" type="line"/>
-      <point x="189" y="823" type="line"/>
-      <point x="299" y="1456" type="line"/>
-      <point x="651" y="1455" type="line" smooth="yes"/>
-      <point x="757" y="1453"/>
-      <point x="927" y="1388"/>
-      <point x="990" y="1333" type="qcurve" smooth="yes"/>
-      <point x="1050" y="1282"/>
-      <point x="1134" y="1137"/>
-      <point x="1154" y="1054" type="qcurve" smooth="yes"/>
-      <point x="1169" y="993"/>
-      <point x="1176" y="857"/>
-      <point x="1167" y="787" type="qcurve" smooth="yes"/>
-      <point x="1150" y="667" type="line" smooth="yes"/>
-      <point x="1130" y="530"/>
-      <point x="1012" y="286"/>
-      <point x="921" y="196" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="829" y="105"/>
-      <point x="586" y="-1"/>
-      <point x="441" y="0" type="qcurve" smooth="yes"/>
+      <point x="32" y="0" type="line"/>
+      <point x="143" y="643" type="line"/>
+      <point x="-34" y="643" type="line"/>
+      <point x="-2" y="823" type="line"/>
+      <point x="174" y="823" type="line"/>
+      <point x="284" y="1456" type="line"/>
+      <point x="636" y="1455" type="line" smooth="yes"/>
+      <point x="742" y="1453"/>
+      <point x="912" y="1388"/>
+      <point x="975" y="1333" type="qcurve" smooth="yes"/>
+      <point x="1035" y="1282"/>
+      <point x="1119" y="1137"/>
+      <point x="1139" y="1054" type="qcurve" smooth="yes"/>
+      <point x="1154" y="993"/>
+      <point x="1161" y="857"/>
+      <point x="1152" y="787" type="qcurve" smooth="yes"/>
+      <point x="1135" y="667" type="line" smooth="yes"/>
+      <point x="1115" y="530"/>
+      <point x="997" y="286"/>
+      <point x="906" y="196" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="814" y="105"/>
+      <point x="571" y="-1"/>
+      <point x="426" y="0" type="qcurve" smooth="yes"/>
     </contour>
     <contour>
-      <point x="654" y="643" type="line"/>
-      <point x="434" y="643" type="line"/>
-      <point x="362" y="226" type="line"/>
-      <point x="453" y="224" type="line" smooth="yes"/>
-      <point x="548" y="224"/>
-      <point x="692" y="299"/>
-      <point x="743.0" y="361" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="794" y="422"/>
-      <point x="857" y="582"/>
-      <point x="870" y="667" type="qcurve" smooth="yes"/>
-      <point x="887" y="790" type="line" smooth="yes"/>
-      <point x="893" y="838"/>
-      <point x="894" y="939"/>
-      <point x="887" y="987.0" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="879" y="1035"/>
-      <point x="844" y="1120"/>
-      <point x="815" y="1153" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="785" y="1185"/>
-      <point x="699" y="1224"/>
-      <point x="640" y="1227" type="qcurve" smooth="yes"/>
-      <point x="536" y="1228" type="line"/>
-      <point x="465" y="823" type="line"/>
-      <point x="686" y="823" type="line"/>
+      <point x="639" y="643" type="line"/>
+      <point x="419" y="643" type="line"/>
+      <point x="347" y="226" type="line"/>
+      <point x="438" y="224" type="line" smooth="yes"/>
+      <point x="533" y="224"/>
+      <point x="677" y="299"/>
+      <point x="728.0" y="361" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="779" y="422"/>
+      <point x="842" y="582"/>
+      <point x="855" y="667" type="qcurve" smooth="yes"/>
+      <point x="872" y="790" type="line" smooth="yes"/>
+      <point x="878" y="838"/>
+      <point x="879" y="939"/>
+      <point x="872" y="987.0" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="864" y="1035"/>
+      <point x="829" y="1120"/>
+      <point x="800" y="1153" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="770" y="1185"/>
+      <point x="684" y="1224"/>
+      <point x="625" y="1227" type="qcurve" smooth="yes"/>
+      <point x="521" y="1228" type="line"/>
+      <point x="450" y="823" type="line"/>
+      <point x="671" y="823" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/RobotoMono-BoldItalic.ufo/glyphs/I_otatonos.glif
+++ b/sources/RobotoMono-BoldItalic.ufo/glyphs/I_otatonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Iotatonos" format="2">
-  <advance width="1302"/>
+  <advance width="1202"/>
   <unicode hex="038A"/>
   <outline>
-    <component base="I" xOffset="100"/>
-    <component base="tonos" xOffset="-619" yOffset="2"/>
+    <component base="I" xOffset="50"/>
+    <component base="tonos" xOffset="-629" yOffset="2"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-BoldItalic.ufo/glyphs/O_megatonos.glif
+++ b/sources/RobotoMono-BoldItalic.ufo/glyphs/O_megatonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegatonos" format="2">
-  <advance width="1222"/>
+  <advance width="1202"/>
   <unicode hex="038F"/>
   <outline>
-    <component base="Omega" xOffset="20"/>
-    <component base="tonos" xOffset="-636"/>
+    <component base="Omega" xOffset="10"/>
+    <component base="tonos" xOffset="-633"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-BoldItalic.ufo/glyphs/O_microntonos.glif
+++ b/sources/RobotoMono-BoldItalic.ufo/glyphs/O_microntonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omicrontonos" format="2">
-  <advance width="1222"/>
+  <advance width="1202"/>
   <unicode hex="038C"/>
   <outline>
-    <component base="O" xOffset="20"/>
-    <component base="tonos" xOffset="-681"/>
+    <component base="O" xOffset="10"/>
+    <component base="tonos" xOffset="-651"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-BoldItalic.ufo/glyphs/U_psilontonos.glif
+++ b/sources/RobotoMono-BoldItalic.ufo/glyphs/U_psilontonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Upsilontonos" format="2">
-  <advance width="1302"/>
+  <advance width="1202"/>
   <unicode hex="038E"/>
   <outline>
-    <component base="Y" xOffset="100"/>
-    <component base="tonos" xOffset="-733"/>
+    <component base="Y" xOffset="38"/>
+    <component base="tonos" xOffset="-783"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-BoldItalic.ufo/glyphs/acutecomb.glif
+++ b/sources/RobotoMono-BoldItalic.ufo/glyphs/acutecomb.glif
@@ -1,6 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="acutecomb" format="2">
-  <advance width="1202"/>
   <unicode hex="0301"/>
   <outline>
     <contour>

--- a/sources/RobotoMono-BoldItalic.ufo/glyphs/contents.plist
+++ b/sources/RobotoMono-BoldItalic.ufo/glyphs/contents.plist
@@ -1140,6 +1140,10 @@
     <string>underscore.glif</string>
     <key>underscoredbl</key>
     <string>underscoredbl.glif</string>
+    <key>uni0002</key>
+    <string>uni0002.glif</string>
+    <key>uni0009</key>
+    <string>uni0009.glif</string>
     <key>uni00AD</key>
     <string>uni00A_D_.glif</string>
     <key>uni010A</key>

--- a/sources/RobotoMono-BoldItalic.ufo/glyphs/dcaron.glif
+++ b/sources/RobotoMono-BoldItalic.ufo/glyphs/dcaron.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="dcaron" format="2">
-  <advance width="1352"/>
+  <advance width="1202"/>
   <unicode hex="010F"/>
   <outline>
-    <component base="d"/>
-    <component base="quoteright" xOffset="768"/>
+    <component base="d" xOffset="-74" yOffset="-1"/>
+    <component base="quoteright" xOffset="598"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-BoldItalic.ufo/glyphs/dcroat.glif
+++ b/sources/RobotoMono-BoldItalic.ufo/glyphs/dcroat.glif
@@ -1,84 +1,84 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="dcroat" format="2">
-  <advance width="1232"/>
+  <advance width="1202"/>
   <unicode hex="0111"/>
   <outline>
     <contour>
-      <point x="1319" y="1220" type="line"/>
-      <point x="1156" y="1220" type="line"/>
-      <point x="945" y="0" type="line"/>
-      <point x="702" y="0" type="line"/>
-      <point x="716" y="113" type="line"/>
-      <point x="692" y="86"/>
-      <point x="638" y="41"/>
-      <point x="608" y="24" type="qcurve" smooth="yes"/>
-      <point x="569" y="2"/>
-      <point x="480" y="-21"/>
-      <point x="430" y="-20" type="qcurve" smooth="yes"/>
-      <point x="358" y="-18"/>
-      <point x="250" y="31"/>
-      <point x="211" y="72" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="172" y="112"/>
-      <point x="122" y="218"/>
-      <point x="109" y="278" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="96" y="337"/>
-      <point x="91" y="462"/>
-      <point x="97" y="521" type="qcurve" smooth="yes"/>
-      <point x="100" y="543" type="line" smooth="yes"/>
-      <point x="108" y="610"/>
-      <point x="144" y="746"/>
-      <point x="173" y="809" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="201" y="872"/>
-      <point x="280" y="981"/>
-      <point x="332" y="1021" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="384" y="1060"/>
-      <point x="512" y="1104"/>
-      <point x="590" y="1102" type="qcurve" smooth="yes"/>
-      <point x="631" y="1101"/>
-      <point x="704" y="1083"/>
-      <point x="737" y="1066" type="qcurve" smooth="yes"/>
-      <point x="764" y="1051"/>
-      <point x="813" y="1010"/>
-      <point x="835" y="983" type="qcurve"/>
-      <point x="879" y="1220" type="line"/>
-      <point x="646" y="1220" type="line"/>
-      <point x="678" y="1400" type="line"/>
-      <point x="913" y="1400" type="line"/>
-      <point x="939" y="1536" type="line"/>
-      <point x="1211" y="1536" type="line"/>
-      <point x="1187" y="1400" type="line"/>
-      <point x="1351" y="1400" type="line"/>
+      <point x="1304" y="1220" type="line"/>
+      <point x="1141" y="1220" type="line"/>
+      <point x="930" y="0" type="line"/>
+      <point x="687" y="0" type="line"/>
+      <point x="701" y="113" type="line"/>
+      <point x="677" y="86"/>
+      <point x="623" y="41"/>
+      <point x="593" y="24" type="qcurve" smooth="yes"/>
+      <point x="554" y="2"/>
+      <point x="465" y="-21"/>
+      <point x="415" y="-20" type="qcurve" smooth="yes"/>
+      <point x="343" y="-18"/>
+      <point x="235" y="31"/>
+      <point x="196" y="72" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="157" y="112"/>
+      <point x="107" y="218"/>
+      <point x="94" y="278" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="81" y="337"/>
+      <point x="76" y="462"/>
+      <point x="82" y="521" type="qcurve" smooth="yes"/>
+      <point x="85" y="543" type="line" smooth="yes"/>
+      <point x="93" y="610"/>
+      <point x="129" y="746"/>
+      <point x="158" y="809" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="186" y="872"/>
+      <point x="265" y="981"/>
+      <point x="317" y="1021" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="369" y="1060"/>
+      <point x="497" y="1104"/>
+      <point x="575" y="1102" type="qcurve" smooth="yes"/>
+      <point x="616" y="1101"/>
+      <point x="689" y="1083"/>
+      <point x="722" y="1066" type="qcurve" smooth="yes"/>
+      <point x="749" y="1051"/>
+      <point x="798" y="1010"/>
+      <point x="820" y="983" type="qcurve"/>
+      <point x="864" y="1220" type="line"/>
+      <point x="631" y="1220" type="line"/>
+      <point x="663" y="1400" type="line"/>
+      <point x="898" y="1400" type="line"/>
+      <point x="924" y="1536" type="line"/>
+      <point x="1196" y="1536" type="line"/>
+      <point x="1172" y="1400" type="line"/>
+      <point x="1336" y="1400" type="line"/>
     </contour>
     <contour>
-      <point x="369" y="521" type="line" smooth="yes"/>
-      <point x="365" y="485"/>
-      <point x="363" y="401"/>
-      <point x="368" y="361" type="qcurve" smooth="yes"/>
-      <point x="373" y="323"/>
-      <point x="395" y="273"/>
-      <point x="419" y="245" type="qcurve" smooth="yes"/>
-      <point x="435" y="227"/>
-      <point x="485" y="207"/>
-      <point x="517" y="206" type="qcurve" smooth="yes"/>
-      <point x="546" y="205"/>
-      <point x="599" y="217"/>
-      <point x="621" y="228" type="qcurve" smooth="yes"/>
-      <point x="652" y="243"/>
-      <point x="705" y="291"/>
-      <point x="727" y="321" type="qcurve"/>
-      <point x="805" y="761" type="line"/>
-      <point x="795" y="789"/>
-      <point x="764" y="831"/>
-      <point x="744" y="846" type="qcurve" smooth="yes"/>
-      <point x="724" y="861"/>
-      <point x="671" y="877"/>
-      <point x="640" y="878" type="qcurve" smooth="yes"/>
-      <point x="572" y="879"/>
-      <point x="476" y="817"/>
-      <point x="444" y="768" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="412" y="719"/>
-      <point x="378" y="599"/>
-      <point x="371" y="542" type="qcurve" smooth="yes"/>
+      <point x="354" y="521" type="line" smooth="yes"/>
+      <point x="350" y="485"/>
+      <point x="348" y="401"/>
+      <point x="353" y="361" type="qcurve" smooth="yes"/>
+      <point x="358" y="323"/>
+      <point x="380" y="273"/>
+      <point x="404" y="245" type="qcurve" smooth="yes"/>
+      <point x="420" y="227"/>
+      <point x="470" y="207"/>
+      <point x="502" y="206" type="qcurve" smooth="yes"/>
+      <point x="531" y="205"/>
+      <point x="584" y="217"/>
+      <point x="606" y="228" type="qcurve" smooth="yes"/>
+      <point x="637" y="243"/>
+      <point x="690" y="291"/>
+      <point x="712" y="321" type="qcurve"/>
+      <point x="790" y="761" type="line"/>
+      <point x="780" y="789"/>
+      <point x="749" y="831"/>
+      <point x="729" y="846" type="qcurve" smooth="yes"/>
+      <point x="709" y="861"/>
+      <point x="656" y="877"/>
+      <point x="625" y="878" type="qcurve" smooth="yes"/>
+      <point x="557" y="879"/>
+      <point x="461" y="817"/>
+      <point x="429" y="768" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="397" y="719"/>
+      <point x="363" y="599"/>
+      <point x="356" y="542" type="qcurve" smooth="yes"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/RobotoMono-BoldItalic.ufo/glyphs/dotbelow.glif
+++ b/sources/RobotoMono-BoldItalic.ufo/glyphs/dotbelow.glif
@@ -1,6 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="dotbelow" format="2">
-  <advance width="1202"/>
   <unicode hex="0323"/>
   <outline>
     <contour>

--- a/sources/RobotoMono-BoldItalic.ufo/glyphs/exclamdbl.glif
+++ b/sources/RobotoMono-BoldItalic.ufo/glyphs/exclamdbl.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="exclamdbl" format="2">
-  <advance width="2404"/>
+  <advance width="1202"/>
   <unicode hex="203C"/>
   <outline>
-    <component base="exclam"/>
-    <component base="exclam" xOffset="1202"/>
+    <component base="exclam" xOffset="-384"/>
+    <component base="exclam" xOffset="412"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-BoldItalic.ufo/glyphs/gravecomb.glif
+++ b/sources/RobotoMono-BoldItalic.ufo/glyphs/gravecomb.glif
@@ -1,6 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="gravecomb" format="2">
-  <advance width="1202"/>
   <unicode hex="0300"/>
   <outline>
     <contour>

--- a/sources/RobotoMono-BoldItalic.ufo/glyphs/hbar.glif
+++ b/sources/RobotoMono-BoldItalic.ufo/glyphs/hbar.glif
@@ -1,49 +1,49 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="hbar" format="2">
-  <advance width="1232"/>
+  <advance width="1202"/>
   <unicode hex="0127"/>
   <outline>
     <contour>
-      <point x="790" y="1216" type="line"/>
-      <point x="539" y="1216" type="line"/>
-      <point x="485" y="931" type="line"/>
-      <point x="517" y="973"/>
-      <point x="594" y="1041"/>
-      <point x="638" y="1063" type="qcurve" smooth="yes"/>
-      <point x="674" y="1082"/>
-      <point x="756" y="1102"/>
-      <point x="801" y="1102" type="qcurve" smooth="yes"/>
-      <point x="897" y="1101"/>
-      <point x="1026" y="1025"/>
-      <point x="1063" y="963" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="1099" y="900"/>
-      <point x="1122" y="740"/>
-      <point x="1113" y="655" type="qcurve"/>
-      <point x="1004" y="0" type="line"/>
-      <point x="732" y="0" type="line"/>
-      <point x="843" y="658" type="line"/>
-      <point x="848" y="703"/>
-      <point x="839" y="780"/>
-      <point x="821" y="810" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="803" y="839"/>
-      <point x="739" y="873"/>
-      <point x="690" y="875" type="qcurve" smooth="yes"/>
-      <point x="658" y="876"/>
-      <point x="601" y="865"/>
-      <point x="575" y="854" type="qcurve" smooth="yes"/>
-      <point x="547" y="842"/>
-      <point x="495" y="805"/>
-      <point x="471" y="782" type="qcurve"/>
-      <point x="333" y="0" type="line"/>
-      <point x="62" y="0" type="line"/>
-      <point x="273" y="1216" type="line"/>
-      <point x="117" y="1216" type="line"/>
-      <point x="149" y="1396" type="line"/>
-      <point x="304" y="1396" type="line"/>
-      <point x="329" y="1536" type="line"/>
-      <point x="600" y="1536" type="line"/>
-      <point x="573" y="1396" type="line"/>
-      <point x="822" y="1396" type="line"/>
+      <point x="775" y="1216" type="line"/>
+      <point x="524" y="1216" type="line"/>
+      <point x="470" y="931" type="line"/>
+      <point x="502" y="973"/>
+      <point x="579" y="1041"/>
+      <point x="623" y="1063" type="qcurve" smooth="yes"/>
+      <point x="659" y="1082"/>
+      <point x="741" y="1102"/>
+      <point x="786" y="1102" type="qcurve" smooth="yes"/>
+      <point x="882" y="1101"/>
+      <point x="1011" y="1025"/>
+      <point x="1048" y="963" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="1084" y="900"/>
+      <point x="1107" y="740"/>
+      <point x="1098" y="655" type="qcurve"/>
+      <point x="989" y="0" type="line"/>
+      <point x="717" y="0" type="line"/>
+      <point x="828" y="658" type="line"/>
+      <point x="833" y="703"/>
+      <point x="824" y="780"/>
+      <point x="806" y="810" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="788" y="839"/>
+      <point x="724" y="873"/>
+      <point x="675" y="875" type="qcurve" smooth="yes"/>
+      <point x="643" y="876"/>
+      <point x="586" y="865"/>
+      <point x="560" y="854" type="qcurve" smooth="yes"/>
+      <point x="532" y="842"/>
+      <point x="480" y="805"/>
+      <point x="456" y="782" type="qcurve"/>
+      <point x="318" y="0" type="line"/>
+      <point x="47" y="0" type="line"/>
+      <point x="258" y="1216" type="line"/>
+      <point x="102" y="1216" type="line"/>
+      <point x="134" y="1396" type="line"/>
+      <point x="289" y="1396" type="line"/>
+      <point x="314" y="1536" type="line"/>
+      <point x="585" y="1536" type="line"/>
+      <point x="558" y="1396" type="line"/>
+      <point x="807" y="1396" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/RobotoMono-BoldItalic.ufo/glyphs/hook.glif
+++ b/sources/RobotoMono-BoldItalic.ufo/glyphs/hook.glif
@@ -1,6 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="hook" format="2">
-  <advance width="1202"/>
   <unicode hex="0309"/>
   <outline>
     <contour>

--- a/sources/RobotoMono-BoldItalic.ufo/glyphs/lcaron.glif
+++ b/sources/RobotoMono-BoldItalic.ufo/glyphs/lcaron.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="lcaron" format="2">
-  <advance width="1352"/>
+  <advance width="1202"/>
   <unicode hex="013E"/>
   <outline>
-    <component base="l"/>
-    <component base="quoteright" xOffset="481" yOffset="-19"/>
+    <component base="l" xOffset="-75"/>
+    <component base="quoteright" xOffset="371" yOffset="-19"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-BoldItalic.ufo/glyphs/ldot.glif
+++ b/sources/RobotoMono-BoldItalic.ufo/glyphs/ldot.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ldot" format="2">
-  <advance width="1422"/>
+  <advance width="1202"/>
   <unicode hex="0140"/>
   <outline>
-    <component base="l"/>
-    <component base="dotaccent" xOffset="316" yOffset="-551"/>
+    <component base="l" xOffset="-75"/>
+    <component base="dotaccent" xOffset="241" yOffset="-551"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-BoldItalic.ufo/glyphs/tcaron.glif
+++ b/sources/RobotoMono-BoldItalic.ufo/glyphs/tcaron.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="tcaron" format="2">
-  <advance width="1242"/>
+  <advance width="1202"/>
   <unicode hex="0165"/>
   <outline>
-    <component base="t"/>
-    <component base="quoteright" xOffset="469" yOffset="163"/>
+    <component base="t" xOffset="-20"/>
+    <component base="quoteright" xOffset="449" yOffset="163"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-BoldItalic.ufo/glyphs/tildecomb.glif
+++ b/sources/RobotoMono-BoldItalic.ufo/glyphs/tildecomb.glif
@@ -1,6 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="tildecomb" format="2">
-  <advance width="1202"/>
   <unicode hex="0303"/>
   <outline>
     <component base="tilde" xOffset="-1010"/>

--- a/sources/RobotoMono-BoldItalic.ufo/glyphs/uni0002.glif
+++ b/sources/RobotoMono-BoldItalic.ufo/glyphs/uni0002.glif
@@ -1,0 +1,7 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni0002" format="2">
+  <advance width="1202"/>
+  <unicode hex="0002"/>
+  <outline>
+  </outline>
+</glyph>

--- a/sources/RobotoMono-BoldItalic.ufo/glyphs/uni0009.glif
+++ b/sources/RobotoMono-BoldItalic.ufo/glyphs/uni0009.glif
@@ -1,0 +1,7 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni0009" format="2">
+  <advance width="1202"/>
+  <unicode hex="0009"/>
+  <outline>
+  </outline>
+</glyph>

--- a/sources/RobotoMono-BoldItalic.ufo/glyphs/uni030F_.glif
+++ b/sources/RobotoMono-BoldItalic.ufo/glyphs/uni030F_.glif
@@ -1,6 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni030F" format="2">
-  <advance width="1202"/>
   <unicode hex="030F"/>
   <outline>
     <contour>

--- a/sources/RobotoMono-BoldItalic.ufo/glyphs/uni0483.glif
+++ b/sources/RobotoMono-BoldItalic.ufo/glyphs/uni0483.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni0483" format="2">
-  <advance width="10"/>
+  <advance width="1202"/>
   <unicode hex="0483"/>
   <outline>
     <contour>

--- a/sources/RobotoMono-BoldItalic.ufo/glyphs/uni0484.glif
+++ b/sources/RobotoMono-BoldItalic.ufo/glyphs/uni0484.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni0484" format="2">
-  <advance width="10"/>
+  <advance width="1202"/>
   <unicode hex="0484"/>
   <outline>
     <contour>

--- a/sources/RobotoMono-BoldItalic.ufo/glyphs/uni0485.glif
+++ b/sources/RobotoMono-BoldItalic.ufo/glyphs/uni0485.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni0485" format="2">
-  <advance width="10"/>
+  <advance width="1202"/>
   <unicode hex="0485"/>
   <outline>
     <contour>

--- a/sources/RobotoMono-BoldItalic.ufo/glyphs/uni0486.glif
+++ b/sources/RobotoMono-BoldItalic.ufo/glyphs/uni0486.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni0486" format="2">
-  <advance width="10"/>
+  <advance width="1202"/>
   <unicode hex="0486"/>
   <outline>
     <contour>

--- a/sources/RobotoMono-BoldItalic.ufo/glyphs/uni0488.glif
+++ b/sources/RobotoMono-BoldItalic.ufo/glyphs/uni0488.glif
@@ -1,231 +1,231 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni0488" format="2">
-  <advance width="10"/>
+  <advance width="1202"/>
   <unicode hex="0488"/>
   <outline>
     <contour>
-      <point x="-525" y="1268" type="line"/>
-      <point x="-519" y="1311"/>
-      <point x="-483" y="1381"/>
-      <point x="-454" y="1406" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="-426" y="1430"/>
-      <point x="-351" y="1456"/>
-      <point x="-306" y="1455" type="qcurve" smooth="yes"/>
-      <point x="-260" y="1454"/>
-      <point x="-187" y="1426"/>
-      <point x="-163" y="1400" type="qcurve" smooth="yes"/>
-      <point x="-140" y="1376"/>
-      <point x="-117" y="1308"/>
-      <point x="-118" y="1266" type="qcurve"/>
-      <point x="-227" y="1266" type="line"/>
-      <point x="-226" y="1287"/>
-      <point x="-232" y="1324"/>
-      <point x="-240" y="1338" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="-249" y="1352"/>
-      <point x="-281" y="1368"/>
-      <point x="-305" y="1368" type="qcurve" smooth="yes"/>
-      <point x="-330" y="1368"/>
-      <point x="-367" y="1351"/>
-      <point x="-380" y="1336" type="qcurve" smooth="yes"/>
-      <point x="-392" y="1323"/>
-      <point x="-409" y="1288"/>
-      <point x="-414" y="1268" type="qcurve"/>
+      <point x="518" y="1268" type="line"/>
+      <point x="524" y="1311"/>
+      <point x="560" y="1381"/>
+      <point x="589" y="1406" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="617" y="1430"/>
+      <point x="692" y="1456"/>
+      <point x="737" y="1455" type="qcurve" smooth="yes"/>
+      <point x="783" y="1454"/>
+      <point x="856" y="1426"/>
+      <point x="880" y="1400" type="qcurve" smooth="yes"/>
+      <point x="903" y="1376"/>
+      <point x="926" y="1308"/>
+      <point x="925" y="1266" type="qcurve"/>
+      <point x="816" y="1266" type="line"/>
+      <point x="817" y="1287"/>
+      <point x="811" y="1324"/>
+      <point x="803" y="1338" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="794" y="1352"/>
+      <point x="762" y="1368"/>
+      <point x="738" y="1368" type="qcurve" smooth="yes"/>
+      <point x="713" y="1368"/>
+      <point x="676" y="1351"/>
+      <point x="663" y="1336" type="qcurve" smooth="yes"/>
+      <point x="651" y="1323"/>
+      <point x="634" y="1288"/>
+      <point x="629" y="1268" type="qcurve"/>
     </contour>
     <contour>
-      <point x="0" y="991" type="line"/>
-      <point x="6" y="1034"/>
-      <point x="42" y="1104"/>
-      <point x="71" y="1129" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="99" y="1153"/>
-      <point x="173" y="1179"/>
-      <point x="218" y="1178" type="qcurve" smooth="yes"/>
-      <point x="265" y="1177"/>
-      <point x="340" y="1148"/>
-      <point x="364" y="1121" type="qcurve" smooth="yes"/>
-      <point x="386" y="1097"/>
-      <point x="408" y="1030"/>
-      <point x="407" y="989" type="qcurve"/>
-      <point x="297" y="989" type="line"/>
-      <point x="298" y="1010"/>
-      <point x="292" y="1047"/>
-      <point x="284" y="1061" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="275" y="1075"/>
-      <point x="243" y="1091"/>
-      <point x="219" y="1091" type="qcurve" smooth="yes"/>
-      <point x="194" y="1091"/>
-      <point x="158" y="1074"/>
-      <point x="145" y="1059" type="qcurve" smooth="yes"/>
-      <point x="133" y="1046"/>
-      <point x="116" y="1011"/>
-      <point x="111" y="991" type="qcurve"/>
+      <point x="1043" y="991" type="line"/>
+      <point x="1049" y="1034"/>
+      <point x="1085" y="1104"/>
+      <point x="1114" y="1129" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="1142" y="1153"/>
+      <point x="1216" y="1179"/>
+      <point x="1261" y="1178" type="qcurve" smooth="yes"/>
+      <point x="1308" y="1177"/>
+      <point x="1383" y="1148"/>
+      <point x="1407" y="1121" type="qcurve" smooth="yes"/>
+      <point x="1429" y="1097"/>
+      <point x="1451" y="1030"/>
+      <point x="1450" y="989" type="qcurve"/>
+      <point x="1340" y="989" type="line"/>
+      <point x="1341" y="1010"/>
+      <point x="1335" y="1047"/>
+      <point x="1327" y="1061" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="1318" y="1075"/>
+      <point x="1286" y="1091"/>
+      <point x="1262" y="1091" type="qcurve" smooth="yes"/>
+      <point x="1237" y="1091"/>
+      <point x="1201" y="1074"/>
+      <point x="1188" y="1059" type="qcurve" smooth="yes"/>
+      <point x="1176" y="1046"/>
+      <point x="1159" y="1011"/>
+      <point x="1154" y="991" type="qcurve"/>
     </contour>
     <contour>
-      <point x="96" y="487" type="line"/>
-      <point x="102" y="530"/>
-      <point x="137" y="601"/>
-      <point x="166" y="626" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="194" y="650"/>
-      <point x="268" y="676"/>
-      <point x="313" y="675" type="qcurve" smooth="yes"/>
-      <point x="363" y="674"/>
-      <point x="440" y="641"/>
-      <point x="464" y="611" type="qcurve" smooth="yes"/>
-      <point x="483" y="587"/>
-      <point x="502" y="524"/>
-      <point x="501" y="486" type="qcurve"/>
-      <point x="391" y="486" type="line"/>
-      <point x="392" y="507"/>
-      <point x="387" y="544"/>
-      <point x="378" y="558" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="369" y="572"/>
-      <point x="338" y="588"/>
-      <point x="314" y="588" type="qcurve" smooth="yes"/>
-      <point x="287" y="588"/>
-      <point x="247" y="567"/>
-      <point x="234" y="549" type="qcurve" smooth="yes"/>
-      <point x="224" y="537"/>
-      <point x="210" y="505"/>
-      <point x="205" y="488" type="qcurve"/>
+      <point x="1139" y="487" type="line"/>
+      <point x="1145" y="530"/>
+      <point x="1180" y="601"/>
+      <point x="1209" y="626" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="1237" y="650"/>
+      <point x="1311" y="676"/>
+      <point x="1356" y="675" type="qcurve" smooth="yes"/>
+      <point x="1406" y="674"/>
+      <point x="1483" y="641"/>
+      <point x="1507" y="611" type="qcurve" smooth="yes"/>
+      <point x="1526" y="587"/>
+      <point x="1545" y="524"/>
+      <point x="1544" y="486" type="qcurve"/>
+      <point x="1434" y="486" type="line"/>
+      <point x="1435" y="507"/>
+      <point x="1430" y="544"/>
+      <point x="1421" y="558" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="1412" y="572"/>
+      <point x="1381" y="588"/>
+      <point x="1357" y="588" type="qcurve" smooth="yes"/>
+      <point x="1330" y="588"/>
+      <point x="1290" y="567"/>
+      <point x="1277" y="549" type="qcurve" smooth="yes"/>
+      <point x="1267" y="537"/>
+      <point x="1253" y="505"/>
+      <point x="1248" y="488" type="qcurve"/>
     </contour>
     <contour>
-      <point x="-184" y="-32" type="line"/>
-      <point x="-179" y="11"/>
-      <point x="-143" y="82"/>
-      <point x="-115" y="107" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="-87" y="131"/>
-      <point x="-13" y="157"/>
-      <point x="32" y="156" type="qcurve" smooth="yes"/>
-      <point x="78" y="155"/>
-      <point x="152" y="126"/>
-      <point x="176" y="99" type="qcurve" smooth="yes"/>
-      <point x="198" y="75"/>
-      <point x="221" y="8"/>
-      <point x="220" y="-33" type="qcurve"/>
-      <point x="110" y="-33" type="line"/>
-      <point x="111" y="-12"/>
-      <point x="106" y="25"/>
-      <point x="97" y="39" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="88" y="53"/>
-      <point x="57" y="69"/>
-      <point x="33" y="69" type="qcurve" smooth="yes"/>
-      <point x="5" y="69"/>
-      <point x="-35" y="47"/>
-      <point x="-48" y="29" type="qcurve" smooth="yes"/>
-      <point x="-58" y="17"/>
-      <point x="-71" y="-14"/>
-      <point x="-76" y="-31" type="qcurve"/>
+      <point x="859" y="-32" type="line"/>
+      <point x="864" y="11"/>
+      <point x="900" y="82"/>
+      <point x="928" y="107" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="956" y="131"/>
+      <point x="1030" y="157"/>
+      <point x="1075" y="156" type="qcurve" smooth="yes"/>
+      <point x="1121" y="155"/>
+      <point x="1195" y="126"/>
+      <point x="1219" y="99" type="qcurve" smooth="yes"/>
+      <point x="1241" y="75"/>
+      <point x="1264" y="8"/>
+      <point x="1263" y="-33" type="qcurve"/>
+      <point x="1153" y="-33" type="line"/>
+      <point x="1154" y="-12"/>
+      <point x="1149" y="25"/>
+      <point x="1140" y="39" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="1131" y="53"/>
+      <point x="1100" y="69"/>
+      <point x="1076" y="69" type="qcurve" smooth="yes"/>
+      <point x="1048" y="69"/>
+      <point x="1008" y="47"/>
+      <point x="995" y="29" type="qcurve" smooth="yes"/>
+      <point x="985" y="17"/>
+      <point x="972" y="-14"/>
+      <point x="967" y="-31" type="qcurve"/>
     </contour>
     <contour>
-      <point x="-794" y="-315" type="line"/>
-      <point x="-788" y="-272"/>
-      <point x="-752" y="-202"/>
-      <point x="-724" y="-177" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="-696" y="-153"/>
-      <point x="-621" y="-127"/>
-      <point x="-576" y="-128" type="qcurve" smooth="yes"/>
-      <point x="-526" y="-129"/>
-      <point x="-448" y="-163"/>
-      <point x="-423" y="-194" type="qcurve" smooth="yes"/>
-      <point x="-405" y="-217"/>
-      <point x="-386" y="-280"/>
-      <point x="-387" y="-317" type="qcurve"/>
-      <point x="-497" y="-317" type="line"/>
-      <point x="-496" y="-296"/>
-      <point x="-502" y="-259"/>
-      <point x="-510" y="-245" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="-519" y="-231"/>
-      <point x="-550" y="-215"/>
-      <point x="-574" y="-215" type="qcurve" smooth="yes"/>
-      <point x="-603" y="-215"/>
-      <point x="-645" y="-239"/>
-      <point x="-658" y="-259" type="qcurve" smooth="yes"/>
-      <point x="-667" y="-271"/>
-      <point x="-679" y="-300"/>
-      <point x="-683" y="-315" type="qcurve"/>
+      <point x="249" y="-315" type="line"/>
+      <point x="255" y="-272"/>
+      <point x="291" y="-202"/>
+      <point x="319" y="-177" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="347" y="-153"/>
+      <point x="422" y="-127"/>
+      <point x="467" y="-128" type="qcurve" smooth="yes"/>
+      <point x="517" y="-129"/>
+      <point x="595" y="-163"/>
+      <point x="620" y="-194" type="qcurve" smooth="yes"/>
+      <point x="638" y="-217"/>
+      <point x="657" y="-280"/>
+      <point x="656" y="-317" type="qcurve"/>
+      <point x="546" y="-317" type="line"/>
+      <point x="547" y="-296"/>
+      <point x="541" y="-259"/>
+      <point x="533" y="-245" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="524" y="-231"/>
+      <point x="493" y="-215"/>
+      <point x="469" y="-215" type="qcurve" smooth="yes"/>
+      <point x="440" y="-215"/>
+      <point x="398" y="-239"/>
+      <point x="385" y="-259" type="qcurve" smooth="yes"/>
+      <point x="376" y="-271"/>
+      <point x="364" y="-300"/>
+      <point x="360" y="-315" type="qcurve"/>
     </contour>
     <contour>
-      <point x="-1129" y="991" type="line"/>
-      <point x="-1124" y="1030"/>
-      <point x="-1093" y="1095"/>
-      <point x="-1069" y="1118" type="qcurve" smooth="yes"/>
-      <point x="-1040" y="1148"/>
-      <point x="-958" y="1179"/>
-      <point x="-909" y="1178" type="qcurve" smooth="yes"/>
-      <point x="-863" y="1177"/>
-      <point x="-790" y="1148"/>
-      <point x="-765" y="1122" type="qcurve" smooth="yes"/>
-      <point x="-743" y="1098"/>
-      <point x="-720" y="1030"/>
-      <point x="-721" y="989" type="qcurve"/>
-      <point x="-830" y="989" type="line"/>
-      <point x="-829" y="1010"/>
-      <point x="-835" y="1047"/>
-      <point x="-843" y="1061" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="-852" y="1075"/>
-      <point x="-884" y="1091"/>
-      <point x="-908" y="1091" type="qcurve" smooth="yes"/>
-      <point x="-933" y="1091"/>
-      <point x="-970" y="1073"/>
-      <point x="-984" y="1058" type="qcurve" smooth="yes"/>
-      <point x="-995" y="1045"/>
-      <point x="-1012" y="1010"/>
-      <point x="-1017" y="991" type="qcurve"/>
+      <point x="-86" y="991" type="line"/>
+      <point x="-81" y="1030"/>
+      <point x="-50" y="1095"/>
+      <point x="-26" y="1118" type="qcurve" smooth="yes"/>
+      <point x="3" y="1148"/>
+      <point x="85" y="1179"/>
+      <point x="134" y="1178" type="qcurve" smooth="yes"/>
+      <point x="180" y="1177"/>
+      <point x="253" y="1148"/>
+      <point x="278" y="1122" type="qcurve" smooth="yes"/>
+      <point x="300" y="1098"/>
+      <point x="323" y="1030"/>
+      <point x="322" y="989" type="qcurve"/>
+      <point x="213" y="989" type="line"/>
+      <point x="214" y="1010"/>
+      <point x="208" y="1047"/>
+      <point x="200" y="1061" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="191" y="1075"/>
+      <point x="159" y="1091"/>
+      <point x="135" y="1091" type="qcurve" smooth="yes"/>
+      <point x="110" y="1091"/>
+      <point x="73" y="1073"/>
+      <point x="59" y="1058" type="qcurve" smooth="yes"/>
+      <point x="48" y="1045"/>
+      <point x="31" y="1010"/>
+      <point x="26" y="991" type="qcurve"/>
     </contour>
     <contour>
-      <point x="-1385" y="487" type="line"/>
-      <point x="-1379" y="530"/>
-      <point x="-1344" y="601"/>
-      <point x="-1315" y="626" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="-1287" y="650"/>
-      <point x="-1212" y="676"/>
-      <point x="-1167" y="675" type="qcurve" smooth="yes"/>
-      <point x="-1115" y="674"/>
-      <point x="-1035" y="637"/>
-      <point x="-1012" y="604" type="qcurve" smooth="yes"/>
-      <point x="-996" y="581"/>
-      <point x="-979" y="521"/>
-      <point x="-980" y="486" type="qcurve"/>
-      <point x="-1089" y="486" type="line"/>
-      <point x="-1088" y="507"/>
-      <point x="-1094" y="544"/>
-      <point x="-1102" y="558" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="-1111" y="572"/>
-      <point x="-1143" y="588"/>
-      <point x="-1167" y="588" type="qcurve" smooth="yes"/>
-      <point x="-1191" y="588"/>
-      <point x="-1226" y="572"/>
-      <point x="-1239" y="559" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="-1252" y="545"/>
-      <point x="-1270" y="509"/>
-      <point x="-1276" y="488" type="qcurve"/>
+      <point x="-342" y="487" type="line"/>
+      <point x="-336" y="530"/>
+      <point x="-301" y="601"/>
+      <point x="-272" y="626" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="-244" y="650"/>
+      <point x="-169" y="676"/>
+      <point x="-124" y="675" type="qcurve" smooth="yes"/>
+      <point x="-72" y="674"/>
+      <point x="8" y="637"/>
+      <point x="31" y="604" type="qcurve" smooth="yes"/>
+      <point x="47" y="581"/>
+      <point x="64" y="521"/>
+      <point x="63" y="486" type="qcurve"/>
+      <point x="-46" y="486" type="line"/>
+      <point x="-45" y="507"/>
+      <point x="-51" y="544"/>
+      <point x="-59" y="558" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="-68" y="572"/>
+      <point x="-100" y="588"/>
+      <point x="-124" y="588" type="qcurve" smooth="yes"/>
+      <point x="-148" y="588"/>
+      <point x="-183" y="572"/>
+      <point x="-196" y="559" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="-209" y="545"/>
+      <point x="-227" y="509"/>
+      <point x="-233" y="488" type="qcurve"/>
     </contour>
     <contour>
-      <point x="-1314" y="-32" type="line"/>
-      <point x="-1308" y="11"/>
-      <point x="-1273" y="82"/>
-      <point x="-1244" y="107" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="-1216" y="131"/>
-      <point x="-1141" y="157"/>
-      <point x="-1096" y="156" type="qcurve" smooth="yes"/>
-      <point x="-1046" y="155"/>
-      <point x="-969" y="121"/>
-      <point x="-944" y="90" type="qcurve" smooth="yes"/>
-      <point x="-926" y="67"/>
-      <point x="-907" y="4"/>
-      <point x="-907" y="-33" type="qcurve"/>
-      <point x="-1018" y="-33" type="line"/>
-      <point x="-1017" y="-12"/>
-      <point x="-1023" y="25"/>
-      <point x="-1031" y="39" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="-1040" y="53"/>
-      <point x="-1071" y="69"/>
-      <point x="-1095" y="69" type="qcurve" smooth="yes"/>
-      <point x="-1123" y="69"/>
-      <point x="-1162" y="48"/>
-      <point x="-1176" y="31" type="qcurve" smooth="yes"/>
-      <point x="-1185" y="18"/>
-      <point x="-1199" y="-14"/>
-      <point x="-1204" y="-31" type="qcurve"/>
+      <point x="-271" y="-32" type="line"/>
+      <point x="-265" y="11"/>
+      <point x="-230" y="82"/>
+      <point x="-201" y="107" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="-173" y="131"/>
+      <point x="-98" y="157"/>
+      <point x="-53" y="156" type="qcurve" smooth="yes"/>
+      <point x="-3" y="155"/>
+      <point x="74" y="121"/>
+      <point x="99" y="90" type="qcurve" smooth="yes"/>
+      <point x="117" y="67"/>
+      <point x="136" y="4"/>
+      <point x="136" y="-33" type="qcurve"/>
+      <point x="25" y="-33" type="line"/>
+      <point x="26" y="-12"/>
+      <point x="20" y="25"/>
+      <point x="12" y="39" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="3" y="53"/>
+      <point x="-28" y="69"/>
+      <point x="-52" y="69" type="qcurve" smooth="yes"/>
+      <point x="-80" y="69"/>
+      <point x="-119" y="48"/>
+      <point x="-133" y="31" type="qcurve" smooth="yes"/>
+      <point x="-142" y="18"/>
+      <point x="-156" y="-14"/>
+      <point x="-161" y="-31" type="qcurve"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/RobotoMono-BoldItalic.ufo/glyphs/uni0489.glif
+++ b/sources/RobotoMono-BoldItalic.ufo/glyphs/uni0489.glif
@@ -1,63 +1,63 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni0489" format="2">
-  <advance width="10"/>
+  <advance width="1202"/>
   <unicode hex="0489"/>
   <outline>
     <contour>
-      <point x="-667" y="-58" type="line"/>
-      <point x="-654" y="-75" type="line"/>
-      <point x="-824" y="-413" type="line"/>
-      <point x="-926" y="-413" type="line"/>
-      <point x="-800" y="-61" type="line"/>
+      <point x="577" y="-58" type="line"/>
+      <point x="590" y="-75" type="line"/>
+      <point x="420" y="-413" type="line"/>
+      <point x="318" y="-413" type="line"/>
+      <point x="444" y="-61" type="line"/>
     </contour>
     <contour>
-      <point x="-637" y="1124" type="line"/>
-      <point x="-651" y="1141" type="line"/>
-      <point x="-481" y="1478" type="line"/>
-      <point x="-379" y="1478" type="line"/>
-      <point x="-505" y="1127" type="line"/>
+      <point x="607" y="1124" type="line"/>
+      <point x="593" y="1141" type="line"/>
+      <point x="763" y="1478" type="line"/>
+      <point x="865" y="1478" type="line"/>
+      <point x="739" y="1127" type="line"/>
     </contour>
     <contour>
-      <point x="-78" y="632" type="line"/>
-      <point x="-68" y="642" type="line"/>
-      <point x="244" y="514" type="line"/>
-      <point x="227" y="424" type="line"/>
-      <point x="-91" y="492" type="line"/>
+      <point x="1166" y="632" type="line"/>
+      <point x="1176" y="642" type="line"/>
+      <point x="1488" y="514" type="line"/>
+      <point x="1471" y="424" type="line"/>
+      <point x="1153" y="492" type="line"/>
     </contour>
     <contour>
-      <point x="-1229" y="432" type="line"/>
-      <point x="-1239" y="422" type="line"/>
-      <point x="-1552" y="550" type="line"/>
-      <point x="-1535" y="640" type="line"/>
-      <point x="-1216" y="572" type="line"/>
+      <point x="15" y="432" type="line"/>
+      <point x="5" y="422" type="line"/>
+      <point x="-308" y="550" type="line"/>
+      <point x="-291" y="640" type="line"/>
+      <point x="28" y="572" type="line"/>
     </contour>
     <contour>
-      <point x="-242" y="1002" type="line"/>
-      <point x="-240" y="1020" type="line"/>
-      <point x="91" y="1172" type="line"/>
-      <point x="154" y="1094" type="line"/>
-      <point x="-150" y="904" type="line"/>
+      <point x="1002" y="1002" type="line"/>
+      <point x="1004" y="1020" type="line"/>
+      <point x="1335" y="1172" type="line"/>
+      <point x="1398" y="1094" type="line"/>
+      <point x="1094" y="904" type="line"/>
     </contour>
     <contour>
-      <point x="-1072" y="21" type="line"/>
-      <point x="-1075" y="2" type="line"/>
-      <point x="-1405" y="-150" type="line"/>
-      <point x="-1469" y="-71" type="line"/>
-      <point x="-1164" y="119" type="line"/>
+      <point x="172" y="21" type="line"/>
+      <point x="169" y="2" type="line"/>
+      <point x="-161" y="-150" type="line"/>
+      <point x="-225" y="-71" type="line"/>
+      <point x="80" y="119" type="line"/>
     </contour>
     <contour>
-      <point x="-1054" y="860" type="line"/>
-      <point x="-1071" y="861" type="line"/>
-      <point x="-1166" y="1200" type="line"/>
-      <point x="-1101" y="1259" type="line"/>
-      <point x="-951" y="956" type="line"/>
+      <point x="190" y="860" type="line"/>
+      <point x="173" y="861" type="line"/>
+      <point x="78" y="1200" type="line"/>
+      <point x="143" y="1259" type="line"/>
+      <point x="293" y="956" type="line"/>
     </contour>
     <contour>
-      <point x="-263" y="161" type="line"/>
-      <point x="-244" y="159" type="line"/>
-      <point x="-150" y="-178" type="line"/>
-      <point x="-216" y="-239" type="line"/>
-      <point x="-365" y="64" type="line"/>
+      <point x="981" y="161" type="line"/>
+      <point x="1000" y="159" type="line"/>
+      <point x="1094" y="-178" type="line"/>
+      <point x="1028" y="-239" type="line"/>
+      <point x="879" y="64" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/RobotoMono-BoldItalic.ufo/glyphs/uni049E_.glif
+++ b/sources/RobotoMono-BoldItalic.ufo/glyphs/uni049E_.glif
@@ -1,30 +1,30 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni049E" format="2">
-  <advance width="1222"/>
+  <advance width="1202"/>
   <unicode hex="049E"/>
   <outline>
     <contour>
-      <point x="747" y="1137" type="line"/>
-      <point x="530" y="1137" type="line"/>
-      <point x="471" y="813" type="line"/>
-      <point x="534" y="814" type="line"/>
-      <point x="1016" y="1456" type="line"/>
-      <point x="1348" y="1456" type="line"/>
-      <point x="795" y="743" type="line"/>
-      <point x="1097" y="0" type="line"/>
-      <point x="794" y="0" type="line"/>
-      <point x="559" y="598" type="line"/>
-      <point x="440" y="598" type="line"/>
-      <point x="336" y="0" type="line"/>
-      <point x="62" y="0" type="line"/>
-      <point x="259" y="1137" type="line"/>
-      <point x="74" y="1137" type="line"/>
-      <point x="106" y="1317" type="line"/>
-      <point x="290" y="1317" type="line"/>
-      <point x="314" y="1456" type="line"/>
-      <point x="589" y="1456" type="line"/>
-      <point x="563" y="1317" type="line"/>
-      <point x="779" y="1317" type="line"/>
+      <point x="737" y="1137" type="line"/>
+      <point x="520" y="1137" type="line"/>
+      <point x="461" y="813" type="line"/>
+      <point x="524" y="814" type="line"/>
+      <point x="1006" y="1456" type="line"/>
+      <point x="1338" y="1456" type="line"/>
+      <point x="785" y="743" type="line"/>
+      <point x="1087" y="0" type="line"/>
+      <point x="784" y="0" type="line"/>
+      <point x="549" y="598" type="line"/>
+      <point x="430" y="598" type="line"/>
+      <point x="326" y="0" type="line"/>
+      <point x="52" y="0" type="line"/>
+      <point x="249" y="1137" type="line"/>
+      <point x="64" y="1137" type="line"/>
+      <point x="96" y="1317" type="line"/>
+      <point x="280" y="1317" type="line"/>
+      <point x="304" y="1456" type="line"/>
+      <point x="579" y="1456" type="line"/>
+      <point x="553" y="1317" type="line"/>
+      <point x="769" y="1317" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/RobotoMono-BoldItalic.ufo/glyphs/uni049F_.glif
+++ b/sources/RobotoMono-BoldItalic.ufo/glyphs/uni049F_.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni049F" format="2">
-  <advance width="1222"/>
+  <advance width="1202"/>
   <unicode hex="049F"/>
   <outline>
     <contour>

--- a/sources/RobotoMono-BoldItalic.ufo/glyphs/uni20A_B_.glif
+++ b/sources/RobotoMono-BoldItalic.ufo/glyphs/uni20A_B_.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni20AB" format="2">
-  <advance width="1232"/>
+  <advance width="1202"/>
   <unicode hex="20AB"/>
   <outline>
-    <component base="d"/>
+    <component base="d" xOffset="-15"/>
     <component base="crossbar" xOffset="347" yOffset="572"/>
-    <component base="underscore" xOffset="30" yOffset="-105"/>
+    <component base="underscore" xOffset="15" yOffset="-105"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-BoldItalic.ufo/glyphs/uniF_F_F_D_.glif
+++ b/sources/RobotoMono-BoldItalic.ufo/glyphs/uniF_F_F_D_.glif
@@ -1,77 +1,77 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uniFFFD" format="2">
-  <advance width="1229"/>
+  <advance width="1202"/>
   <unicode hex="FFFD"/>
   <outline>
     <contour>
-      <point x="610" y="1618" type="line"/>
-      <point x="1199" y="643" type="line"/>
-      <point x="610" y="-332" type="line"/>
-      <point x="15" y="643" type="line"/>
+      <point x="597" y="1618" type="line"/>
+      <point x="1186" y="643" type="line"/>
+      <point x="597" y="-332" type="line"/>
+      <point x="2" y="643" type="line"/>
     </contour>
     <contour>
-      <point x="713" y="392" type="line"/>
-      <point x="713" y="417"/>
-      <point x="719" y="456"/>
-      <point x="725.0" y="471.5" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="731" y="487"/>
-      <point x="748" y="516"/>
-      <point x="759" y="532" type="qcurve" smooth="yes"/>
-      <point x="781" y="563"/>
-      <point x="826" y="618"/>
-      <point x="844.0" y="646.5" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="862" y="675"/>
-      <point x="885" y="739"/>
-      <point x="885" y="780" type="qcurve" smooth="yes"/>
-      <point x="885" y="844"/>
-      <point x="848" y="947"/>
-      <point x="813.5" y="983.5" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="779" y="1020"/>
-      <point x="677" y="1059"/>
-      <point x="613" y="1059" type="qcurve" smooth="yes"/>
-      <point x="557" y="1059"/>
-      <point x="460" y="1029"/>
-      <point x="423.5" y="996.5" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="387" y="964"/>
-      <point x="344" y="863"/>
-      <point x="343" y="793" type="qcurve"/>
-      <point x="546" y="793" type="line"/>
-      <point x="548" y="848"/>
-      <point x="589" y="896"/>
-      <point x="613" y="896" type="qcurve" smooth="yes"/>
-      <point x="650" y="896"/>
-      <point x="682" y="832"/>
-      <point x="682" y="780" type="qcurve" smooth="yes"/>
-      <point x="682" y="754"/>
-      <point x="665" y="703"/>
-      <point x="653.0" y="679.5" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="641" y="656"/>
-      <point x="614" y="617"/>
-      <point x="604" y="604" type="qcurve" smooth="yes"/>
-      <point x="575" y="568"/>
-      <point x="540" y="528"/>
-      <point x="529.5" y="509.0" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="519" y="490"/>
-      <point x="511" y="440"/>
-      <point x="511" y="392" type="qcurve"/>
+      <point x="700" y="392" type="line"/>
+      <point x="700" y="417"/>
+      <point x="706" y="456"/>
+      <point x="712.0" y="472" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="718" y="487"/>
+      <point x="735" y="516"/>
+      <point x="746" y="532" type="qcurve" smooth="yes"/>
+      <point x="768" y="563"/>
+      <point x="813" y="618"/>
+      <point x="831.0" y="647" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="849" y="675"/>
+      <point x="872" y="739"/>
+      <point x="872" y="780" type="qcurve" smooth="yes"/>
+      <point x="872" y="844"/>
+      <point x="835" y="947"/>
+      <point x="801" y="984" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="766" y="1020"/>
+      <point x="664" y="1059"/>
+      <point x="600" y="1059" type="qcurve" smooth="yes"/>
+      <point x="544" y="1059"/>
+      <point x="447" y="1029"/>
+      <point x="411" y="997" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="374" y="964"/>
+      <point x="331" y="863"/>
+      <point x="330" y="793" type="qcurve"/>
+      <point x="533" y="793" type="line"/>
+      <point x="535" y="848"/>
+      <point x="576" y="896"/>
+      <point x="600" y="896" type="qcurve" smooth="yes"/>
+      <point x="637" y="896"/>
+      <point x="669" y="832"/>
+      <point x="669" y="780" type="qcurve" smooth="yes"/>
+      <point x="669" y="754"/>
+      <point x="652" y="703"/>
+      <point x="640.0" y="680" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="628" y="656"/>
+      <point x="601" y="617"/>
+      <point x="591" y="604" type="qcurve" smooth="yes"/>
+      <point x="562" y="568"/>
+      <point x="527" y="528"/>
+      <point x="517" y="509.0" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="506" y="490"/>
+      <point x="498" y="440"/>
+      <point x="498" y="392" type="qcurve"/>
     </contour>
     <contour>
-      <point x="713" y="301" type="line"/>
-      <point x="511" y="301" type="line"/>
-      <point x="511" y="131" type="line"/>
-      <point x="713" y="131" type="line"/>
+      <point x="700" y="301" type="line"/>
+      <point x="498" y="301" type="line"/>
+      <point x="498" y="131" type="line"/>
+      <point x="700" y="131" type="line"/>
     </contour>
     <contour>
-      <point x="605" y="-551" type="line"/>
-      <point x="609" y="-551" type="line"/>
-      <point x="609" y="-555" type="line"/>
-      <point x="605" y="-555" type="line"/>
+      <point x="592" y="-551" type="line"/>
+      <point x="596" y="-551" type="line"/>
+      <point x="596" y="-555" type="line"/>
+      <point x="592" y="-555" type="line"/>
     </contour>
     <contour>
-      <point x="603" y="2163" type="line"/>
-      <point x="607" y="2163" type="line"/>
-      <point x="607" y="2159" type="line"/>
-      <point x="603" y="2159" type="line"/>
+      <point x="590" y="2163" type="line"/>
+      <point x="594" y="2163" type="line"/>
+      <point x="594" y="2159" type="line"/>
+      <point x="590" y="2159" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/RobotoMono-BoldItalic.ufo/lib.plist
+++ b/sources/RobotoMono-BoldItalic.ufo/lib.plist
@@ -6,43 +6,11 @@
     <array>
       <dict>
         <key>allowPseudoUnicode</key>
-        <true/>
+        <integer>0</integer>
         <key>ascending</key>
-        <true/>
+        <string>Amstelvar DB Best</string>
         <key>type</key>
-        <string>alphabetical</string>
-      </dict>
-      <dict>
-        <key>allowPseudoUnicode</key>
-        <true/>
-        <key>ascending</key>
-        <true/>
-        <key>type</key>
-        <string>category</string>
-      </dict>
-      <dict>
-        <key>allowPseudoUnicode</key>
-        <true/>
-        <key>ascending</key>
-        <true/>
-        <key>type</key>
-        <string>unicode</string>
-      </dict>
-      <dict>
-        <key>allowPseudoUnicode</key>
-        <true/>
-        <key>ascending</key>
-        <true/>
-        <key>type</key>
-        <string>script</string>
-      </dict>
-      <dict>
-        <key>allowPseudoUnicode</key>
-        <true/>
-        <key>ascending</key>
-        <true/>
-        <key>type</key>
-        <string>suffix</string>
+        <string>characterSet</string>
       </dict>
     </array>
     <key>com.typemytype.robofont.binarySource</key>
@@ -69,6 +37,8 @@
     <integer>1</integer>
     <key>public.glyphOrder</key>
     <array>
+      <string>NULL</string>
+      <string>space</string>
       <string>A</string>
       <string>B</string>
       <string>C</string>
@@ -95,111 +65,347 @@
       <string>X</string>
       <string>Y</string>
       <string>Z</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
+      <string>a</string>
+      <string>b</string>
+      <string>c</string>
+      <string>d</string>
+      <string>e</string>
+      <string>f</string>
+      <string>g</string>
+      <string>h</string>
+      <string>i</string>
+      <string>j</string>
+      <string>k</string>
+      <string>l</string>
+      <string>m</string>
+      <string>n</string>
+      <string>o</string>
+      <string>p</string>
+      <string>q</string>
+      <string>r</string>
+      <string>s</string>
+      <string>t</string>
+      <string>u</string>
+      <string>v</string>
+      <string>w</string>
+      <string>x</string>
+      <string>y</string>
+      <string>z</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
+      <string>onesuperior</string>
+      <string>twosuperior</string>
+      <string>threesuperior</string>
+      <string>ordfeminine</string>
+      <string>ordmasculine</string>
+      <string>onehalf</string>
+      <string>onequarter</string>
+      <string>threequarters</string>
       <string>AE</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
-      <string>Iacute</string>
-      <string>Icircumflex</string>
-      <string>Idieresis</string>
-      <string>Eth</string>
-      <string>Ntilde</string>
-      <string>Ograve</string>
-      <string>Oacute</string>
-      <string>Ocircumflex</string>
-      <string>Otilde</string>
-      <string>Odieresis</string>
-      <string>Oslash</string>
-      <string>Ugrave</string>
-      <string>Uacute</string>
-      <string>Ucircumflex</string>
-      <string>Udieresis</string>
-      <string>Yacute</string>
+      <string>ae</string>
+      <string>OE</string>
+      <string>oe</string>
+      <string>eth</string>
       <string>Thorn</string>
-      <string>Amacron</string>
+      <string>thorn</string>
+      <string>kgreenlandic</string>
+      <string>germandbls</string>
+      <string>schwa</string>
+      <string>dollar</string>
+      <string>cent</string>
+      <string>sterling</string>
+      <string>yen</string>
+      <string>florin</string>
+      <string>franc</string>
+      <string>lira</string>
+      <string>peseta</string>
+      <string>currency</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>comma</string>
+      <string>period</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>ellipsis</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>underscore</string>
+      <string>hyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>quotesingle</string>
+      <string>quotedbl</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quotedblbase</string>
+      <string>minute</string>
+      <string>second</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>plusminus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>approxequal</string>
+      <string>less</string>
+      <string>greater</string>
+      <string>lessequal</string>
+      <string>greaterequal</string>
+      <string>logicalnot</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>fraction</string>
+      <string>percent</string>
+      <string>perthousand</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>dagger</string>
+      <string>daggerdbl</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>ampersand</string>
+      <string>at</string>
+      <string>section</string>
+      <string>paragraph</string>
+      <string>asciicircum</string>
+      <string>asciitilde</string>
+      <string>Aacute</string>
       <string>Abreve</string>
+      <string>Acircumflex</string>
+      <string>Adieresis</string>
+      <string>Agrave</string>
+      <string>Amacron</string>
       <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Aringacute</string>
+      <string>Atilde</string>
+      <string>AEacute</string>
       <string>Cacute</string>
-      <string>Ccircumflex</string>
-      <string>uni010A</string>
       <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Ccircumflex</string>
       <string>Dcaron</string>
       <string>Dcroat</string>
-      <string>Emacron</string>
+      <string>Eacute</string>
       <string>Ebreve</string>
-      <string>Edotaccent</string>
-      <string>Eogonek</string>
       <string>Ecaron</string>
-      <string>Gcircumflex</string>
+      <string>Ecircumflex</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Egrave</string>
+      <string>Emacron</string>
+      <string>Eng</string>
+      <string>Eogonek</string>
+      <string>Eth</string>
       <string>Gbreve</string>
-      <string>uni0120</string>
+      <string>Gcircumflex</string>
       <string>Gcommaaccent</string>
-      <string>Hcircumflex</string>
       <string>Hbar</string>
-      <string>Itilde</string>
-      <string>Imacron</string>
+      <string>Hcircumflex</string>
+      <string>Iacute</string>
       <string>Ibreve</string>
-      <string>Iogonek</string>
+      <string>Icircumflex</string>
+      <string>Idieresis</string>
       <string>Idotaccent</string>
-      <string>IJ</string>
+      <string>Igrave</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
       <string>Jcircumflex</string>
       <string>Kcommaaccent</string>
       <string>Lacute</string>
-      <string>Lcommaaccent</string>
       <string>Lcaron</string>
+      <string>Lcommaaccent</string>
       <string>Ldot</string>
       <string>Lslash</string>
       <string>Nacute</string>
-      <string>Ncommaaccent</string>
       <string>Ncaron</string>
-      <string>Eng</string>
-      <string>Omacron</string>
+      <string>Ncommaaccent</string>
+      <string>Ntilde</string>
+      <string>Oacute</string>
       <string>Obreve</string>
+      <string>Ocircumflex</string>
+      <string>Odieresis</string>
+      <string>Ograve</string>
+      <string>Ohorn</string>
       <string>Ohungarumlaut</string>
-      <string>OE</string>
+      <string>Omacron</string>
+      <string>Oslash</string>
+      <string>Oslashacute</string>
+      <string>Otilde</string>
       <string>Racute</string>
-      <string>Rcommaaccent</string>
       <string>Rcaron</string>
+      <string>Rcommaaccent</string>
       <string>Sacute</string>
-      <string>Scircumflex</string>
-      <string>Scedilla</string>
       <string>Scaron</string>
-      <string>uni0162</string>
-      <string>Tcaron</string>
+      <string>Scedilla</string>
+      <string>Scircumflex</string>
       <string>Tbar</string>
-      <string>Utilde</string>
-      <string>Umacron</string>
+      <string>Tcaron</string>
+      <string>Uacute</string>
       <string>Ubreve</string>
-      <string>Uring</string>
+      <string>Ucircumflex</string>
+      <string>Udieresis</string>
+      <string>Ugrave</string>
+      <string>Uhorn</string>
       <string>Uhungarumlaut</string>
+      <string>Umacron</string>
       <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>Wacute</string>
       <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>Yacute</string>
       <string>Ycircumflex</string>
       <string>Ydieresis</string>
+      <string>Ygrave</string>
       <string>Zacute</string>
-      <string>Zdotaccent</string>
       <string>Zcaron</string>
-      <string>Ohorn</string>
-      <string>Uhorn</string>
-      <string>Aringacute</string>
-      <string>AEacute</string>
-      <string>Oslashacute</string>
+      <string>Zdotaccent</string>
+      <string>aacute</string>
+      <string>abreve</string>
+      <string>acircumflex</string>
+      <string>adieresis</string>
+      <string>agrave</string>
+      <string>amacron</string>
+      <string>aogonek</string>
+      <string>aring</string>
+      <string>aringacute</string>
+      <string>atilde</string>
+      <string>aeacute</string>
+      <string>cacute</string>
+      <string>ccaron</string>
+      <string>ccedilla</string>
+      <string>ccircumflex</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>eacute</string>
+      <string>ebreve</string>
+      <string>ecaron</string>
+      <string>ecircumflex</string>
+      <string>edieresis</string>
+      <string>edotaccent</string>
+      <string>egrave</string>
+      <string>emacron</string>
+      <string>eng</string>
+      <string>eogonek</string>
+      <string>gbreve</string>
+      <string>gcircumflex</string>
+      <string>gcommaaccent</string>
+      <string>hbar</string>
+      <string>hcircumflex</string>
+      <string>iacute</string>
+      <string>ibreve</string>
+      <string>icircumflex</string>
+      <string>idieresis</string>
+      <string>igrave</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>jcircumflex</string>
+      <string>kcommaaccent</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ntilde</string>
+      <string>oacute</string>
+      <string>obreve</string>
+      <string>ocircumflex</string>
+      <string>odieresis</string>
+      <string>ograve</string>
+      <string>ohorn</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
+      <string>oslash</string>
+      <string>oslashacute</string>
+      <string>otilde</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scircumflex</string>
+      <string>tbar</string>
+      <string>tcaron</string>
+      <string>uacute</string>
+      <string>ubreve</string>
+      <string>ucircumflex</string>
+      <string>udieresis</string>
+      <string>ugrave</string>
+      <string>uhorn</string>
+      <string>uhungarumlaut</string>
+      <string>umacron</string>
+      <string>uogonek</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>wacute</string>
+      <string>wcircumflex</string>
+      <string>wdieresis</string>
+      <string>wgrave</string>
+      <string>yacute</string>
+      <string>ycircumflex</string>
+      <string>ydieresis</string>
+      <string>ygrave</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>circumflex</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>breve</string>
+      <string>dotaccent</string>
+      <string>dieresis</string>
+      <string>ring</string>
+      <string>hungarumlaut</string>
+      <string>caron</string>
+      <string>dotbelow</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
+      <string>commaaccent</string>
+      <string>uni010A</string>
+      <string>uni0120</string>
+      <string>IJ</string>
+      <string>uni0162</string>
       <string>uni0218</string>
       <string>uni021A</string>
       <string>uni1E00</string>
       <string>uni1E3E</string>
-      <string>Wgrave</string>
-      <string>Wacute</string>
-      <string>Wdieresis</string>
       <string>uni1EA0</string>
       <string>uni1EA2</string>
       <string>uni1EA4</string>
@@ -241,7 +447,6 @@
       <string>uni1EEC</string>
       <string>uni1EEE</string>
       <string>uni1EF0</string>
-      <string>Ygrave</string>
       <string>uni1EF4</string>
       <string>uni1EF6</string>
       <string>uni1EF8</string>
@@ -527,145 +732,19 @@
       <string>uni0512</string>
       <string>mu</string>
       <string>uni2113</string>
-      <string>a</string>
-      <string>b</string>
-      <string>c</string>
-      <string>d</string>
-      <string>e</string>
-      <string>f</string>
-      <string>g</string>
-      <string>h</string>
-      <string>i</string>
-      <string>j</string>
-      <string>k</string>
-      <string>l</string>
-      <string>m</string>
-      <string>n</string>
-      <string>o</string>
-      <string>p</string>
-      <string>q</string>
-      <string>r</string>
-      <string>s</string>
-      <string>t</string>
-      <string>u</string>
-      <string>v</string>
-      <string>w</string>
-      <string>x</string>
-      <string>y</string>
-      <string>z</string>
-      <string>germandbls</string>
-      <string>agrave</string>
-      <string>aacute</string>
-      <string>acircumflex</string>
-      <string>atilde</string>
-      <string>adieresis</string>
-      <string>aring</string>
-      <string>ae</string>
-      <string>ccedilla</string>
-      <string>egrave</string>
-      <string>eacute</string>
-      <string>ecircumflex</string>
-      <string>edieresis</string>
-      <string>igrave</string>
-      <string>iacute</string>
-      <string>icircumflex</string>
-      <string>idieresis</string>
-      <string>eth</string>
-      <string>ntilde</string>
-      <string>ograve</string>
-      <string>oacute</string>
-      <string>ocircumflex</string>
-      <string>otilde</string>
-      <string>odieresis</string>
-      <string>oslash</string>
-      <string>ugrave</string>
-      <string>uacute</string>
-      <string>ucircumflex</string>
-      <string>udieresis</string>
-      <string>yacute</string>
-      <string>thorn</string>
-      <string>ydieresis</string>
-      <string>amacron</string>
-      <string>abreve</string>
-      <string>aogonek</string>
-      <string>cacute</string>
-      <string>ccircumflex</string>
       <string>uni010B</string>
-      <string>ccaron</string>
-      <string>dcaron</string>
-      <string>dcroat</string>
-      <string>emacron</string>
-      <string>ebreve</string>
-      <string>edotaccent</string>
-      <string>eogonek</string>
-      <string>ecaron</string>
-      <string>gcircumflex</string>
-      <string>gbreve</string>
       <string>uni0121</string>
-      <string>gcommaaccent</string>
-      <string>hcircumflex</string>
-      <string>hbar</string>
-      <string>itilde</string>
-      <string>imacron</string>
-      <string>ibreve</string>
-      <string>iogonek</string>
       <string>dotlessi</string>
       <string>ij</string>
-      <string>jcircumflex</string>
-      <string>kcommaaccent</string>
-      <string>kgreenlandic</string>
-      <string>lacute</string>
-      <string>lcommaaccent</string>
-      <string>lcaron</string>
-      <string>ldot</string>
-      <string>lslash</string>
-      <string>nacute</string>
-      <string>ncommaaccent</string>
-      <string>ncaron</string>
       <string>napostrophe</string>
-      <string>eng</string>
-      <string>omacron</string>
-      <string>obreve</string>
-      <string>ohungarumlaut</string>
-      <string>oe</string>
-      <string>racute</string>
-      <string>rcommaaccent</string>
-      <string>rcaron</string>
-      <string>sacute</string>
-      <string>scircumflex</string>
-      <string>scedilla</string>
-      <string>scaron</string>
       <string>uni0163</string>
-      <string>tcaron</string>
-      <string>tbar</string>
-      <string>utilde</string>
-      <string>umacron</string>
-      <string>ubreve</string>
-      <string>uring</string>
-      <string>uhungarumlaut</string>
-      <string>uogonek</string>
-      <string>wcircumflex</string>
-      <string>ycircumflex</string>
-      <string>zacute</string>
-      <string>zdotaccent</string>
-      <string>zcaron</string>
       <string>longs</string>
-      <string>florin</string>
-      <string>ohorn</string>
-      <string>uhorn</string>
       <string>uni01F0</string>
-      <string>aringacute</string>
-      <string>aeacute</string>
-      <string>oslashacute</string>
       <string>uni0219</string>
       <string>uni021B</string>
       <string>uni0237</string>
-      <string>schwa</string>
       <string>uni1E01</string>
       <string>uni1E3F</string>
-      <string>wgrave</string>
-      <string>wacute</string>
-      <string>wdieresis</string>
       <string>uni1EA1</string>
       <string>uni1EA3</string>
       <string>uni1EA5</string>
@@ -707,7 +786,6 @@
       <string>uni1EED</string>
       <string>uni1EEF</string>
       <string>uni1EF1</string>
-      <string>ygrave</string>
       <string>uni1EF5</string>
       <string>uni1EF7</string>
       <string>uni1EF9</string>
@@ -884,34 +962,18 @@
       <string>uni0511</string>
       <string>uni0513</string>
       <string>uni02BC</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>macron</string>
       <string>nsuperior</string>
-      <string>ordfeminine</string>
-      <string>ordmasculine</string>
       <string>gravecomb</string>
       <string>acutecomb</string>
       <string>tildecomb</string>
       <string>hook</string>
       <string>uni030F</string>
-      <string>dotbelow</string>
       <string>uni0485</string>
       <string>uni0486</string>
       <string>uni0483</string>
       <string>uni0484</string>
       <string>uni0488</string>
       <string>uni0489</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
       <string>one.sup</string>
       <string>two.sup</string>
       <string>three.sup</string>
@@ -919,129 +981,37 @@
       <string>five.sup</string>
       <string>seven.sup</string>
       <string>eight.sup</string>
-      <string>twosuperior</string>
-      <string>threesuperior</string>
-      <string>onesuperior</string>
-      <string>onequarter</string>
-      <string>onehalf</string>
-      <string>threequarters</string>
       <string>uni2074</string>
       <string>oneeighth</string>
       <string>threeeighths</string>
       <string>fiveeighths</string>
       <string>seveneighths</string>
-      <string>underscore</string>
-      <string>hyphen</string>
-      <string>endash</string>
-      <string>emdash</string>
       <string>uni2015</string>
-      <string>parenleft</string>
-      <string>bracketleft</string>
-      <string>braceleft</string>
-      <string>quotesinglbase</string>
-      <string>quotedblbase</string>
-      <string>parenright</string>
-      <string>bracketright</string>
-      <string>braceright</string>
       <string>guillemotleft</string>
-      <string>quoteleft</string>
       <string>quotereversed</string>
-      <string>quotedblleft</string>
-      <string>guilsinglleft</string>
       <string>guillemotright</string>
-      <string>quoteright</string>
-      <string>quotedblright</string>
-      <string>guilsinglright</string>
-      <string>exclam</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>asterisk</string>
-      <string>comma</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>question</string>
-      <string>at</string>
-      <string>backslash</string>
-      <string>exclamdown</string>
-      <string>section</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>questiondown</string>
       <string>anoteleia</string>
       <string>underscoredbl</string>
-      <string>dagger</string>
-      <string>daggerdbl</string>
-      <string>bullet</string>
       <string>uni2025</string>
-      <string>ellipsis</string>
-      <string>perthousand</string>
-      <string>minute</string>
-      <string>second</string>
       <string>exclamdbl</string>
-      <string>plus</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>bar</string>
-      <string>asciitilde</string>
-      <string>logicalnot</string>
-      <string>plusminus</string>
-      <string>multiply</string>
-      <string>divide</string>
-      <string>fraction</string>
       <string>partialdiff</string>
       <string>product</string>
       <string>summation</string>
-      <string>minus</string>
       <string>radical</string>
       <string>infinity</string>
       <string>integral</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>lessequal</string>
-      <string>greaterequal</string>
-      <string>dollar</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>franc</string>
-      <string>lira</string>
-      <string>peseta</string>
       <string>uni20AB</string>
       <string>Euro</string>
-      <string>asciicircum</string>
-      <string>grave</string>
-      <string>dieresis</string>
-      <string>acute</string>
-      <string>cedilla</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
       <string>uni02F3</string>
       <string>dieresistonos</string>
       <string>tonos</string>
-      <string>brokenbar</string>
-      <string>copyright</string>
-      <string>registered</string>
-      <string>degree</string>
       <string>uni2105</string>
       <string>uni2116</string>
-      <string>trademark</string>
       <string>estimated</string>
       <string>lozenge</string>
       <string>uniFFFC</string>
       <string>uniFFFD</string>
       <string>uni0482</string>
-      <string>space</string>
       <string>nonbreakingspace</string>
       <string>uni2000</string>
       <string>uni2001</string>
@@ -1054,14 +1024,12 @@
       <string>uni2008</string>
       <string>uni2009</string>
       <string>uni200A</string>
-      <string>NULL</string>
       <string>uni0002</string>
       <string>uni0009</string>
       <string>nonmarkingreturn</string>
       <string>uni00AD</string>
       <string>uni200B</string>
       <string>uniFEFF</string>
-      <string>commaaccent</string>
       <string>.notdef</string>
       <string>breveacutecomb</string>
       <string>brevegravecomb</string>

--- a/sources/RobotoMono-Italic.ufo/glyphs/D_croat.glif
+++ b/sources/RobotoMono-Italic.ufo/glyphs/D_croat.glif
@@ -1,57 +1,57 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Dcroat" format="2">
-  <advance width="1232"/>
+  <advance width="1202"/>
   <unicode hex="0110"/>
   <outline>
     <contour>
-      <point x="76" y="0" type="line"/>
-      <point x="191" y="666" type="line"/>
-      <point x="-30" y="666" type="line"/>
-      <point x="-3" y="817" type="line"/>
-      <point x="217" y="817" type="line"/>
-      <point x="328" y="1456" type="line"/>
-      <point x="644" y="1455" type="line" smooth="yes"/>
-      <point x="743" y="1453"/>
-      <point x="905" y="1398"/>
-      <point x="967" y="1350" type="qcurve" smooth="yes"/>
-      <point x="1026.0663805423162" y="1305.7002145932627"/>
-      <point x="1111.2831538902901" y="1181.2492424745362"/>
-      <point x="1136" y="1109" type="qcurve" smooth="yes"/>
-      <point x="1160" y="1036"/>
-      <point x="1173" y="870"/>
-      <point x="1162" y="781" type="qcurve" smooth="yes"/>
-      <point x="1147" y="674" type="line" smooth="yes"/>
-      <point x="1125" y="530"/>
-      <point x="1004" y="284"/>
-      <point x="910" y="194" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="816" y="103"/>
-      <point x="566" y="0"/>
-      <point x="415" y="0" type="qcurve" smooth="yes"/>
+      <point x="61" y="0" type="line"/>
+      <point x="176" y="666" type="line"/>
+      <point x="-45" y="666" type="line"/>
+      <point x="-18" y="817" type="line"/>
+      <point x="202" y="817" type="line"/>
+      <point x="313" y="1456" type="line"/>
+      <point x="629" y="1455" type="line" smooth="yes"/>
+      <point x="728" y="1453"/>
+      <point x="890" y="1398"/>
+      <point x="952" y="1350" type="qcurve" smooth="yes"/>
+      <point x="1011" y="1306"/>
+      <point x="1096" y="1181"/>
+      <point x="1121" y="1109" type="qcurve" smooth="yes"/>
+      <point x="1145" y="1036"/>
+      <point x="1158" y="870"/>
+      <point x="1147" y="781" type="qcurve" smooth="yes"/>
+      <point x="1132" y="674" type="line" smooth="yes"/>
+      <point x="1110" y="530"/>
+      <point x="989" y="284"/>
+      <point x="895" y="194" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="801" y="103"/>
+      <point x="551" y="0"/>
+      <point x="400" y="0" type="qcurve" smooth="yes"/>
     </contour>
     <contour>
-      <point x="589" y="666" type="line"/>
-      <point x="375" y="666" type="line"/>
-      <point x="286" y="151" type="line"/>
-      <point x="419" y="150" type="line" smooth="yes"/>
-      <point x="536" y="151"/>
-      <point x="722" y="233"/>
-      <point x="791" y="304" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="860" y="374"/>
-      <point x="948" y="565"/>
-      <point x="966" y="674" type="qcurve" smooth="yes"/>
-      <point x="982" y="784" type="line" smooth="yes"/>
-      <point x="991" y="851"/>
-      <point x="987" y="983"/>
-      <point x="971" y="1042" type="qcurve" smooth="yes"/>
-      <point x="955.6154334987424" y="1096.9448803616344"/>
-      <point x="900.3670795594383" y="1192.137522198667"/>
-      <point x="860" y="1227" type="qcurve" smooth="yes"/>
-      <point x="820" y="1261"/>
-      <point x="711" y="1300"/>
-      <point x="641" y="1303" type="qcurve" smooth="yes"/>
-      <point x="486" y="1304" type="line"/>
-      <point x="401" y="817" type="line"/>
-      <point x="616" y="817" type="line"/>
+      <point x="574" y="666" type="line"/>
+      <point x="360" y="666" type="line"/>
+      <point x="271" y="151" type="line"/>
+      <point x="404" y="150" type="line" smooth="yes"/>
+      <point x="521" y="151"/>
+      <point x="707" y="233"/>
+      <point x="776" y="304" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="845" y="374"/>
+      <point x="933" y="565"/>
+      <point x="951" y="674" type="qcurve" smooth="yes"/>
+      <point x="967" y="784" type="line" smooth="yes"/>
+      <point x="976" y="851"/>
+      <point x="972" y="983"/>
+      <point x="956" y="1042" type="qcurve" smooth="yes"/>
+      <point x="941" y="1097"/>
+      <point x="885" y="1192"/>
+      <point x="845" y="1227" type="qcurve" smooth="yes"/>
+      <point x="805" y="1261"/>
+      <point x="696" y="1300"/>
+      <point x="626" y="1303" type="qcurve" smooth="yes"/>
+      <point x="471" y="1304" type="line"/>
+      <point x="386" y="817" type="line"/>
+      <point x="601" y="817" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Italic.ufo/glyphs/E_psilontonos.glif
+++ b/sources/RobotoMono-Italic.ufo/glyphs/E_psilontonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Epsilontonos" format="2">
-  <advance width="1302"/>
+  <advance width="1202"/>
   <unicode hex="0388"/>
   <outline>
-    <component base="E" xOffset="100"/>
-    <component base="tonos" xOffset="-519"/>
+    <component base="E" xOffset="50"/>
+    <component base="tonos" xOffset="-569"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Italic.ufo/glyphs/E_tatonos.glif
+++ b/sources/RobotoMono-Italic.ufo/glyphs/E_tatonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etatonos" format="2">
-  <advance width="1302"/>
+  <advance width="1202"/>
   <unicode hex="0389"/>
   <outline>
-    <component base="H" xOffset="100"/>
-    <component base="tonos" xOffset="-536" yOffset="2"/>
+    <component base="H" xOffset="50"/>
+    <component base="tonos" xOffset="-586" yOffset="2"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Italic.ufo/glyphs/E_th.glif
+++ b/sources/RobotoMono-Italic.ufo/glyphs/E_th.glif
@@ -1,57 +1,57 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Eth" format="2">
-  <advance width="1232"/>
+  <advance width="1202"/>
   <unicode hex="00D0"/>
   <outline>
     <contour>
-      <point x="76" y="0" type="line"/>
-      <point x="191" y="666" type="line"/>
-      <point x="-30" y="666" type="line"/>
-      <point x="-3" y="817" type="line"/>
-      <point x="217" y="817" type="line"/>
-      <point x="328" y="1456" type="line"/>
-      <point x="644" y="1455" type="line" smooth="yes"/>
-      <point x="743" y="1453"/>
-      <point x="905" y="1398"/>
-      <point x="967" y="1350" type="qcurve" smooth="yes"/>
-      <point x="1026" y="1306"/>
-      <point x="1111" y="1181"/>
-      <point x="1136" y="1109" type="qcurve" smooth="yes"/>
-      <point x="1160" y="1036"/>
-      <point x="1173" y="870"/>
-      <point x="1162" y="781" type="qcurve" smooth="yes"/>
-      <point x="1147" y="674" type="line" smooth="yes"/>
-      <point x="1125" y="530"/>
-      <point x="1004" y="284"/>
-      <point x="910" y="194" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="816" y="103"/>
-      <point x="566" y="0"/>
-      <point x="415" y="0" type="qcurve" smooth="yes"/>
+      <point x="61" y="0" type="line"/>
+      <point x="176" y="666" type="line"/>
+      <point x="-45" y="666" type="line"/>
+      <point x="-18" y="817" type="line"/>
+      <point x="202" y="817" type="line"/>
+      <point x="313" y="1456" type="line"/>
+      <point x="629" y="1455" type="line" smooth="yes"/>
+      <point x="728" y="1453"/>
+      <point x="890" y="1398"/>
+      <point x="952" y="1350" type="qcurve" smooth="yes"/>
+      <point x="1011" y="1306"/>
+      <point x="1096" y="1181"/>
+      <point x="1121" y="1109" type="qcurve" smooth="yes"/>
+      <point x="1145" y="1036"/>
+      <point x="1158" y="870"/>
+      <point x="1147" y="781" type="qcurve" smooth="yes"/>
+      <point x="1132" y="674" type="line" smooth="yes"/>
+      <point x="1110" y="530"/>
+      <point x="989" y="284"/>
+      <point x="895" y="194" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="801" y="103"/>
+      <point x="551" y="0"/>
+      <point x="400" y="0" type="qcurve" smooth="yes"/>
     </contour>
     <contour>
-      <point x="589" y="666" type="line"/>
-      <point x="375" y="666" type="line"/>
-      <point x="286" y="151" type="line"/>
-      <point x="419" y="150" type="line" smooth="yes"/>
-      <point x="536" y="151"/>
-      <point x="722" y="233"/>
-      <point x="791" y="304" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="860" y="374"/>
-      <point x="948" y="565"/>
-      <point x="966" y="674" type="qcurve" smooth="yes"/>
-      <point x="982" y="784" type="line" smooth="yes"/>
-      <point x="991" y="851"/>
-      <point x="987" y="983"/>
-      <point x="971" y="1042" type="qcurve" smooth="yes"/>
-      <point x="956" y="1097"/>
-      <point x="900" y="1192"/>
-      <point x="860" y="1227" type="qcurve" smooth="yes"/>
-      <point x="820" y="1261"/>
-      <point x="711" y="1300"/>
-      <point x="641" y="1303" type="qcurve" smooth="yes"/>
-      <point x="486" y="1304" type="line"/>
-      <point x="401" y="817" type="line"/>
-      <point x="616" y="817" type="line"/>
+      <point x="574" y="666" type="line"/>
+      <point x="360" y="666" type="line"/>
+      <point x="271" y="151" type="line"/>
+      <point x="404" y="150" type="line" smooth="yes"/>
+      <point x="521" y="151"/>
+      <point x="707" y="233"/>
+      <point x="776" y="304" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="845" y="374"/>
+      <point x="933" y="565"/>
+      <point x="951" y="674" type="qcurve" smooth="yes"/>
+      <point x="967" y="784" type="line" smooth="yes"/>
+      <point x="976" y="851"/>
+      <point x="972" y="983"/>
+      <point x="956" y="1042" type="qcurve" smooth="yes"/>
+      <point x="941" y="1097"/>
+      <point x="885" y="1192"/>
+      <point x="845" y="1227" type="qcurve" smooth="yes"/>
+      <point x="805" y="1261"/>
+      <point x="696" y="1300"/>
+      <point x="626" y="1303" type="qcurve" smooth="yes"/>
+      <point x="471" y="1304" type="line"/>
+      <point x="386" y="817" type="line"/>
+      <point x="601" y="817" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Italic.ufo/glyphs/I_otatonos.glif
+++ b/sources/RobotoMono-Italic.ufo/glyphs/I_otatonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Iotatonos" format="2">
-  <advance width="1302"/>
+  <advance width="1202"/>
   <unicode hex="038A"/>
   <outline>
-    <component base="I" xOffset="100"/>
-    <component base="tonos" xOffset="-552" yOffset="2"/>
+    <component base="I" xOffset="50"/>
+    <component base="tonos" xOffset="-602" yOffset="2"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Italic.ufo/glyphs/O_megatonos.glif
+++ b/sources/RobotoMono-Italic.ufo/glyphs/O_megatonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegatonos" format="2">
-  <advance width="1222"/>
+  <advance width="1202"/>
   <unicode hex="038F"/>
   <outline>
-    <component base="Omega" xOffset="20"/>
-    <component base="tonos" xOffset="-531"/>
+    <component base="Omega" xOffset="10"/>
+    <component base="tonos" xOffset="-541"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Italic.ufo/glyphs/O_microntonos.glif
+++ b/sources/RobotoMono-Italic.ufo/glyphs/O_microntonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omicrontonos" format="2">
-  <advance width="1222"/>
+  <advance width="1202"/>
   <unicode hex="038C"/>
   <outline>
-    <component base="O" xOffset="20"/>
-    <component base="tonos" xOffset="-527"/>
+    <component base="O" xOffset="10"/>
+    <component base="tonos" xOffset="-537"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Italic.ufo/glyphs/U_psilontonos.glif
+++ b/sources/RobotoMono-Italic.ufo/glyphs/U_psilontonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Upsilontonos" format="2">
-  <advance width="1302"/>
+  <advance width="1202"/>
   <unicode hex="038E"/>
   <outline>
-    <component base="Y" xOffset="100"/>
-    <component base="tonos" xOffset="-609"/>
+    <component base="Y" xOffset="50"/>
+    <component base="tonos" xOffset="-659"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Italic.ufo/glyphs/acutecomb.glif
+++ b/sources/RobotoMono-Italic.ufo/glyphs/acutecomb.glif
@@ -1,6 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="acutecomb" format="2">
-  <advance width="1083"/>
   <unicode hex="0301"/>
   <outline>
     <contour>

--- a/sources/RobotoMono-Italic.ufo/glyphs/contents.plist
+++ b/sources/RobotoMono-Italic.ufo/glyphs/contents.plist
@@ -1140,6 +1140,10 @@
     <string>underscore.glif</string>
     <key>underscoredbl</key>
     <string>underscoredbl.glif</string>
+    <key>uni0002</key>
+    <string>uni0002.glif</string>
+    <key>uni0009</key>
+    <string>uni0009.glif</string>
     <key>uni00AD</key>
     <string>uni00A_D_.glif</string>
     <key>uni010A</key>

--- a/sources/RobotoMono-Italic.ufo/glyphs/dcaron.glif
+++ b/sources/RobotoMono-Italic.ufo/glyphs/dcaron.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="dcaron" format="2">
-  <advance width="1352"/>
+  <advance width="1202"/>
   <unicode hex="010F"/>
   <outline>
-    <component base="d"/>
-    <component base="quoteright" xOffset="750" yOffset="-1"/>
+    <component base="d" xOffset="-70"/>
+    <component base="quoteright" xOffset="680" yOffset="-1"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Italic.ufo/glyphs/dcroat.glif
+++ b/sources/RobotoMono-Italic.ufo/glyphs/dcroat.glif
@@ -1,84 +1,84 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="dcroat" format="2">
-  <advance width="1232"/>
+  <advance width="1202"/>
   <unicode hex="0111"/>
   <outline>
     <contour>
-      <point x="1322" y="1234" type="line"/>
-      <point x="1131" y="1234" type="line"/>
-      <point x="917" y="0" type="line"/>
-      <point x="753" y="0" type="line"/>
-      <point x="772" y="114" type="line"/>
-      <point x="746" y="87"/>
-      <point x="690" y="42"/>
-      <point x="659" y="26" type="qcurve" smooth="yes"/>
-      <point x="615" y="2"/>
-      <point x="516" y="-21"/>
-      <point x="461" y="-20" type="qcurve" smooth="yes"/>
-      <point x="391" y="-18"/>
-      <point x="282" y="31"/>
-      <point x="243" y="72" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="203" y="113"/>
-      <point x="152" y="220"/>
-      <point x="138" y="280" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="124" y="339"/>
-      <point x="118" y="463"/>
-      <point x="124" y="522" type="qcurve" smooth="yes"/>
-      <point x="126" y="543" type="line" smooth="yes"/>
-      <point x="134" y="610"/>
-      <point x="172" y="746"/>
-      <point x="202" y="809" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="232" y="872"/>
-      <point x="315" y="980"/>
-      <point x="368" y="1020" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="420" y="1060"/>
-      <point x="550" y="1104"/>
-      <point x="627" y="1102" type="qcurve" smooth="yes"/>
-      <point x="672" y="1101"/>
-      <point x="756" y="1082"/>
-      <point x="793" y="1063" type="qcurve" smooth="yes"/>
-      <point x="823" y="1047"/>
-      <point x="876" y="1003"/>
-      <point x="899" y="974" type="qcurve"/>
-      <point x="947" y="1234" type="line"/>
-      <point x="703" y="1234" type="line"/>
-      <point x="730" y="1385" type="line"/>
-      <point x="975" y="1385" type="line"/>
-      <point x="1003" y="1536" type="line"/>
-      <point x="1184" y="1536" type="line"/>
-      <point x="1158" y="1385" type="line"/>
-      <point x="1349" y="1385" type="line"/>
+      <point x="1307" y="1234" type="line"/>
+      <point x="1116" y="1234" type="line"/>
+      <point x="902" y="0" type="line"/>
+      <point x="738" y="0" type="line"/>
+      <point x="757" y="114" type="line"/>
+      <point x="731" y="87"/>
+      <point x="675" y="42"/>
+      <point x="644" y="26" type="qcurve" smooth="yes"/>
+      <point x="600" y="2"/>
+      <point x="501" y="-21"/>
+      <point x="446" y="-20" type="qcurve" smooth="yes"/>
+      <point x="376" y="-18"/>
+      <point x="267" y="31"/>
+      <point x="228" y="72" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="188" y="113"/>
+      <point x="137" y="220"/>
+      <point x="123" y="280" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="109" y="339"/>
+      <point x="103" y="463"/>
+      <point x="109" y="522" type="qcurve" smooth="yes"/>
+      <point x="111" y="543" type="line" smooth="yes"/>
+      <point x="119" y="610"/>
+      <point x="157" y="746"/>
+      <point x="187" y="809" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="217" y="872"/>
+      <point x="300" y="980"/>
+      <point x="353" y="1020" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="405" y="1060"/>
+      <point x="535" y="1104"/>
+      <point x="612" y="1102" type="qcurve" smooth="yes"/>
+      <point x="657" y="1101"/>
+      <point x="741" y="1082"/>
+      <point x="778" y="1063" type="qcurve" smooth="yes"/>
+      <point x="808" y="1047"/>
+      <point x="861" y="1003"/>
+      <point x="884" y="974" type="qcurve"/>
+      <point x="932" y="1234" type="line"/>
+      <point x="688" y="1234" type="line"/>
+      <point x="715" y="1385" type="line"/>
+      <point x="960" y="1385" type="line"/>
+      <point x="988" y="1536" type="line"/>
+      <point x="1169" y="1536" type="line"/>
+      <point x="1143" y="1385" type="line"/>
+      <point x="1334" y="1385" type="line"/>
     </contour>
     <contour>
-      <point x="304" y="522" type="line" smooth="yes"/>
-      <point x="299" y="482"/>
-      <point x="299" y="394"/>
-      <point x="306" y="352" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="312" y="309"/>
-      <point x="340" y="233"/>
-      <point x="365" y="204" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="390" y="174"/>
-      <point x="464" y="138"/>
-      <point x="515" y="137" type="qcurve" smooth="yes"/>
-      <point x="560" y="135"/>
-      <point x="638" y="158"/>
-      <point x="671" y="178" type="qcurve" smooth="yes"/>
-      <point x="704" y="199"/>
-      <point x="762" y="257"/>
-      <point x="787" y="291" type="qcurve"/>
-      <point x="874" y="796" type="line"/>
-      <point x="858" y="835"/>
-      <point x="809" y="895"/>
-      <point x="777" y="914" type="qcurve" smooth="yes"/>
-      <point x="753" y="929"/>
-      <point x="695" y="945"/>
-      <point x="661" y="946" type="qcurve" smooth="yes"/>
-      <point x="577" y="949"/>
-      <point x="453" y="877"/>
-      <point x="410" y="819" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="367" y="760"/>
-      <point x="316" y="615"/>
-      <point x="307" y="543" type="qcurve" smooth="yes"/>
+      <point x="289" y="522" type="line" smooth="yes"/>
+      <point x="284" y="482"/>
+      <point x="284" y="394"/>
+      <point x="291" y="352" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="297" y="309"/>
+      <point x="325" y="233"/>
+      <point x="350" y="204" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="375" y="174"/>
+      <point x="449" y="138"/>
+      <point x="500" y="137" type="qcurve" smooth="yes"/>
+      <point x="545" y="135"/>
+      <point x="623" y="158"/>
+      <point x="656" y="178" type="qcurve" smooth="yes"/>
+      <point x="689" y="199"/>
+      <point x="747" y="257"/>
+      <point x="772" y="291" type="qcurve"/>
+      <point x="859" y="796" type="line"/>
+      <point x="843" y="835"/>
+      <point x="794" y="895"/>
+      <point x="762" y="914" type="qcurve" smooth="yes"/>
+      <point x="738" y="929"/>
+      <point x="680" y="945"/>
+      <point x="646" y="946" type="qcurve" smooth="yes"/>
+      <point x="562" y="949"/>
+      <point x="438" y="877"/>
+      <point x="395" y="819" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="352" y="760"/>
+      <point x="301" y="615"/>
+      <point x="292" y="543" type="qcurve" smooth="yes"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Italic.ufo/glyphs/dotbelow.glif
+++ b/sources/RobotoMono-Italic.ufo/glyphs/dotbelow.glif
@@ -1,6 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="dotbelow" format="2">
-  <advance width="1083"/>
   <unicode hex="0323"/>
   <outline>
     <contour>

--- a/sources/RobotoMono-Italic.ufo/glyphs/exclamdbl.glif
+++ b/sources/RobotoMono-Italic.ufo/glyphs/exclamdbl.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="exclamdbl" format="2">
-  <advance width="2404"/>
+  <advance width="1202"/>
   <unicode hex="203C"/>
   <outline>
     <component base="exclam"/>
-    <component base="exclam" xOffset="1202"/>
+    <component base="exclam" xOffset="881"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Italic.ufo/glyphs/f.glif
+++ b/sources/RobotoMono-Italic.ufo/glyphs/f.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f" format="2">
-  <advance width="1203"/>
+  <advance width="1202"/>
   <unicode hex="0066"/>
   <outline>
     <contour>

--- a/sources/RobotoMono-Italic.ufo/glyphs/gravecomb.glif
+++ b/sources/RobotoMono-Italic.ufo/glyphs/gravecomb.glif
@@ -1,6 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="gravecomb" format="2">
-  <advance width="1083"/>
   <unicode hex="0300"/>
   <outline>
     <contour>

--- a/sources/RobotoMono-Italic.ufo/glyphs/hbar.glif
+++ b/sources/RobotoMono-Italic.ufo/glyphs/hbar.glif
@@ -1,49 +1,49 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="hbar" format="2">
-  <advance width="1232"/>
+  <advance width="1202"/>
   <unicode hex="0127"/>
   <outline>
     <contour>
-      <point x="755" y="1234" type="line"/>
-      <point x="485" y="1234" type="line"/>
-      <point x="426" y="920" type="line"/>
-      <point x="459" y="960"/>
-      <point x="536" y="1028"/>
-      <point x="579.5" y="1052.0" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="623" y="1076"/>
-      <point x="720" y="1103"/>
-      <point x="774" y="1102" type="qcurve" smooth="yes"/>
-      <point x="866" y="1100"/>
-      <point x="990" y="1030"/>
-      <point x="1026.0" y="972.0" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="1062" y="914"/>
-      <point x="1086" y="763"/>
-      <point x="1077" y="681" type="qcurve"/>
-      <point x="963" y="0" type="line"/>
-      <point x="782" y="0" type="line"/>
-      <point x="897" y="684" type="line"/>
-      <point x="903" y="737"/>
-      <point x="891" y="830"/>
-      <point x="869.0" y="865.5" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="847" y="901"/>
-      <point x="770" y="942"/>
-      <point x="711" y="944" type="qcurve" smooth="yes"/>
-      <point x="665" y="945"/>
-      <point x="582" y="922"/>
-      <point x="544.5" y="900.5" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="507" y="879"/>
-      <point x="440" y="821"/>
-      <point x="412" y="787" type="qcurve"/>
-      <point x="275" y="0" type="line"/>
-      <point x="94" y="0" type="line"/>
-      <point x="308" y="1234" type="line"/>
-      <point x="136" y="1234" type="line"/>
-      <point x="163" y="1385" type="line"/>
-      <point x="334" y="1385" type="line"/>
-      <point x="361" y="1536" type="line"/>
-      <point x="542" y="1536" type="line"/>
-      <point x="513" y="1385" type="line"/>
-      <point x="782" y="1385" type="line"/>
+      <point x="740" y="1234" type="line"/>
+      <point x="470" y="1234" type="line"/>
+      <point x="411" y="920" type="line"/>
+      <point x="444" y="960"/>
+      <point x="521" y="1028"/>
+      <point x="565" y="1052.0" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="608" y="1076"/>
+      <point x="705" y="1103"/>
+      <point x="759" y="1102" type="qcurve" smooth="yes"/>
+      <point x="851" y="1100"/>
+      <point x="975" y="1030"/>
+      <point x="1011.0" y="972.0" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="1047" y="914"/>
+      <point x="1071" y="763"/>
+      <point x="1062" y="681" type="qcurve"/>
+      <point x="948" y="0" type="line"/>
+      <point x="767" y="0" type="line"/>
+      <point x="882" y="684" type="line"/>
+      <point x="888" y="737"/>
+      <point x="876" y="830"/>
+      <point x="854.0" y="866" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="832" y="901"/>
+      <point x="755" y="942"/>
+      <point x="696" y="944" type="qcurve" smooth="yes"/>
+      <point x="650" y="945"/>
+      <point x="567" y="922"/>
+      <point x="530" y="901" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="492" y="879"/>
+      <point x="425" y="821"/>
+      <point x="397" y="787" type="qcurve"/>
+      <point x="260" y="0" type="line"/>
+      <point x="79" y="0" type="line"/>
+      <point x="293" y="1234" type="line"/>
+      <point x="121" y="1234" type="line"/>
+      <point x="148" y="1385" type="line"/>
+      <point x="319" y="1385" type="line"/>
+      <point x="346" y="1536" type="line"/>
+      <point x="527" y="1536" type="line"/>
+      <point x="498" y="1385" type="line"/>
+      <point x="767" y="1385" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Italic.ufo/glyphs/hook.glif
+++ b/sources/RobotoMono-Italic.ufo/glyphs/hook.glif
@@ -1,6 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="hook" format="2">
-  <advance width="1083"/>
   <unicode hex="0309"/>
   <outline>
     <contour>

--- a/sources/RobotoMono-Italic.ufo/glyphs/hyphen.glif
+++ b/sources/RobotoMono-Italic.ufo/glyphs/hyphen.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="hyphen" format="2">
-  <advance width="1203"/>
+  <advance width="1202"/>
   <unicode hex="002D"/>
   <outline>
     <contour>

--- a/sources/RobotoMono-Italic.ufo/glyphs/lcaron.glif
+++ b/sources/RobotoMono-Italic.ufo/glyphs/lcaron.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="lcaron" format="2">
-  <advance width="1352"/>
+  <advance width="1202"/>
   <unicode hex="013E"/>
   <outline>
-    <component base="l"/>
-    <component base="quoteright" xOffset="494" yOffset="-18"/>
+    <component base="l" xOffset="-70"/>
+    <component base="quoteright" xOffset="424" yOffset="-18"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Italic.ufo/glyphs/ldot.glif
+++ b/sources/RobotoMono-Italic.ufo/glyphs/ldot.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ldot" format="2">
-  <advance width="1422"/>
+  <advance width="1202"/>
   <unicode hex="0140"/>
   <outline>
-    <component base="l"/>
-    <component base="dotaccent" xOffset="280" yOffset="-537"/>
+    <component base="l" xOffset="-71"/>
+    <component base="dotaccent" xOffset="209" yOffset="-537"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Italic.ufo/glyphs/tcaron.glif
+++ b/sources/RobotoMono-Italic.ufo/glyphs/tcaron.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="tcaron" format="2">
-  <advance width="1242"/>
+  <advance width="1202"/>
   <unicode hex="0165"/>
   <outline>
-    <component base="t"/>
-    <component base="quoteright" xOffset="427" yOffset="157"/>
+    <component base="t" xOffset="-20"/>
+    <component base="quoteright" xOffset="407" yOffset="157"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Italic.ufo/glyphs/tildecomb.glif
+++ b/sources/RobotoMono-Italic.ufo/glyphs/tildecomb.glif
@@ -1,6 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="tildecomb" format="2">
-  <advance width="1083"/>
   <unicode hex="0303"/>
   <outline>
     <component base="tilde" xOffset="-995"/>

--- a/sources/RobotoMono-Italic.ufo/glyphs/uni0002.glif
+++ b/sources/RobotoMono-Italic.ufo/glyphs/uni0002.glif
@@ -1,0 +1,7 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni0002" format="2">
+  <advance width="1202"/>
+  <unicode hex="0002"/>
+  <outline>
+  </outline>
+</glyph>

--- a/sources/RobotoMono-Italic.ufo/glyphs/uni0009.glif
+++ b/sources/RobotoMono-Italic.ufo/glyphs/uni0009.glif
@@ -1,0 +1,7 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni0009" format="2">
+  <advance width="1202"/>
+  <unicode hex="0009"/>
+  <outline>
+  </outline>
+</glyph>

--- a/sources/RobotoMono-Italic.ufo/glyphs/uni00A_D_.glif
+++ b/sources/RobotoMono-Italic.ufo/glyphs/uni00A_D_.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni00AD" format="2">
-  <advance width="1203"/>
+  <advance width="1202"/>
   <unicode hex="00AD"/>
   <outline>
     <component base="hyphen"/>

--- a/sources/RobotoMono-Italic.ufo/glyphs/uni030F_.glif
+++ b/sources/RobotoMono-Italic.ufo/glyphs/uni030F_.glif
@@ -1,6 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni030F" format="2">
-  <advance width="1083"/>
   <unicode hex="030F"/>
   <outline>
     <contour>

--- a/sources/RobotoMono-Italic.ufo/glyphs/uni0483.glif
+++ b/sources/RobotoMono-Italic.ufo/glyphs/uni0483.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni0483" format="2">
-  <advance width="10"/>
+  <advance width="1202"/>
   <unicode hex="0483"/>
   <outline>
     <contour>

--- a/sources/RobotoMono-Italic.ufo/glyphs/uni0484.glif
+++ b/sources/RobotoMono-Italic.ufo/glyphs/uni0484.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni0484" format="2">
-  <advance width="10"/>
+  <advance width="1202"/>
   <unicode hex="0484"/>
   <outline>
     <contour>

--- a/sources/RobotoMono-Italic.ufo/glyphs/uni0485.glif
+++ b/sources/RobotoMono-Italic.ufo/glyphs/uni0485.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni0485" format="2">
-  <advance width="10"/>
+  <advance width="1202"/>
   <unicode hex="0485"/>
   <outline>
     <contour>

--- a/sources/RobotoMono-Italic.ufo/glyphs/uni0486.glif
+++ b/sources/RobotoMono-Italic.ufo/glyphs/uni0486.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni0486" format="2">
-  <advance width="10"/>
+  <advance width="1202"/>
   <unicode hex="0486"/>
   <outline>
     <contour>

--- a/sources/RobotoMono-Italic.ufo/glyphs/uni0488.glif
+++ b/sources/RobotoMono-Italic.ufo/glyphs/uni0488.glif
@@ -1,231 +1,231 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni0488" format="2">
-  <advance width="10"/>
+  <advance width="1202"/>
   <unicode hex="0488"/>
   <outline>
     <contour>
-      <point x="569" y="1268" type="line"/>
-      <point x="575" y="1311"/>
-      <point x="612" y="1381"/>
-      <point x="641" y="1406" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="669" y="1430"/>
-      <point x="744" y="1456"/>
-      <point x="789" y="1455" type="qcurve" smooth="yes"/>
-      <point x="832" y="1455"/>
-      <point x="902" y="1428"/>
-      <point x="927" y="1403" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="951" y="1378"/>
-      <point x="977" y="1309"/>
-      <point x="976" y="1266" type="qcurve"/>
-      <point x="867" y="1266" type="line"/>
-      <point x="868" y="1287"/>
-      <point x="862" y="1324"/>
-      <point x="853" y="1338" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="844" y="1352"/>
-      <point x="812" y="1368"/>
-      <point x="788" y="1368" type="qcurve" smooth="yes"/>
-      <point x="761" y="1368"/>
-      <point x="723" y="1348"/>
-      <point x="709" y="1331" type="qcurve" smooth="yes"/>
-      <point x="699" y="1318"/>
-      <point x="685" y="1286"/>
-      <point x="680" y="1268" type="qcurve"/>
+      <point x="469" y="1268" type="line"/>
+      <point x="475" y="1311"/>
+      <point x="512" y="1381"/>
+      <point x="541" y="1406" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="569" y="1430"/>
+      <point x="644" y="1456"/>
+      <point x="689" y="1455" type="qcurve" smooth="yes"/>
+      <point x="732" y="1455"/>
+      <point x="802" y="1428"/>
+      <point x="827" y="1403" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="851" y="1378"/>
+      <point x="877" y="1309"/>
+      <point x="876" y="1266" type="qcurve"/>
+      <point x="767" y="1266" type="line"/>
+      <point x="768" y="1287"/>
+      <point x="762" y="1324"/>
+      <point x="753" y="1338" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="744" y="1352"/>
+      <point x="712" y="1368"/>
+      <point x="688" y="1368" type="qcurve" smooth="yes"/>
+      <point x="661" y="1368"/>
+      <point x="623" y="1348"/>
+      <point x="609" y="1331" type="qcurve" smooth="yes"/>
+      <point x="599" y="1318"/>
+      <point x="585" y="1286"/>
+      <point x="580" y="1268" type="qcurve"/>
     </contour>
     <contour>
-      <point x="1094" y="991" type="line"/>
-      <point x="1100" y="1032"/>
-      <point x="1133" y="1098"/>
-      <point x="1159" y="1122" type="qcurve" smooth="yes"/>
-      <point x="1188" y="1150"/>
-      <point x="1267" y="1179"/>
-      <point x="1314" y="1178" type="qcurve" smooth="yes"/>
-      <point x="1359" y="1177"/>
-      <point x="1431" y="1150"/>
-      <point x="1456" y="1124" type="qcurve" smooth="yes"/>
-      <point x="1479" y="1100"/>
-      <point x="1503" y="1031"/>
-      <point x="1502" y="989" type="qcurve"/>
-      <point x="1392" y="989" type="line"/>
-      <point x="1393" y="1010"/>
-      <point x="1387" y="1047"/>
-      <point x="1378" y="1061" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="1369" y="1075"/>
-      <point x="1338" y="1091"/>
-      <point x="1314" y="1091" type="qcurve" smooth="yes"/>
-      <point x="1291" y="1091"/>
-      <point x="1256" y="1076"/>
-      <point x="1243" y="1063" type="qcurve" smooth="yes"/>
-      <point x="1230" y="1049"/>
-      <point x="1212" y="1012"/>
-      <point x="1206" y="991" type="qcurve"/>
+      <point x="994" y="991" type="line"/>
+      <point x="1000" y="1032"/>
+      <point x="1033" y="1098"/>
+      <point x="1059" y="1122" type="qcurve" smooth="yes"/>
+      <point x="1088" y="1150"/>
+      <point x="1167" y="1179"/>
+      <point x="1214" y="1178" type="qcurve" smooth="yes"/>
+      <point x="1259" y="1177"/>
+      <point x="1331" y="1150"/>
+      <point x="1356" y="1124" type="qcurve" smooth="yes"/>
+      <point x="1379" y="1100"/>
+      <point x="1403" y="1031"/>
+      <point x="1402" y="989" type="qcurve"/>
+      <point x="1292" y="989" type="line"/>
+      <point x="1293" y="1010"/>
+      <point x="1287" y="1047"/>
+      <point x="1278" y="1061" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="1269" y="1075"/>
+      <point x="1238" y="1091"/>
+      <point x="1214" y="1091" type="qcurve" smooth="yes"/>
+      <point x="1191" y="1091"/>
+      <point x="1156" y="1076"/>
+      <point x="1143" y="1063" type="qcurve" smooth="yes"/>
+      <point x="1130" y="1049"/>
+      <point x="1112" y="1012"/>
+      <point x="1106" y="991" type="qcurve"/>
     </contour>
     <contour>
-      <point x="1191" y="487" type="line"/>
-      <point x="1197" y="530"/>
-      <point x="1233" y="601"/>
-      <point x="1261" y="626" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="1289" y="650"/>
-      <point x="1364" y="676"/>
-      <point x="1409" y="675" type="qcurve" smooth="yes"/>
-      <point x="1456" y="674"/>
-      <point x="1530" y="643"/>
-      <point x="1554" y="616" type="qcurve" smooth="yes"/>
-      <point x="1574" y="592"/>
-      <point x="1596" y="526"/>
-      <point x="1595" y="486" type="qcurve"/>
-      <point x="1486" y="486" type="line"/>
-      <point x="1487" y="507"/>
-      <point x="1481" y="544"/>
-      <point x="1472" y="558" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="1463" y="572"/>
-      <point x="1432" y="588"/>
-      <point x="1408" y="588" type="qcurve" smooth="yes"/>
-      <point x="1383" y="588"/>
-      <point x="1346" y="571"/>
-      <point x="1333" y="556" type="qcurve" smooth="yes"/>
-      <point x="1321" y="543"/>
-      <point x="1304" y="508"/>
-      <point x="1299" y="488" type="qcurve"/>
+      <point x="1091" y="487" type="line"/>
+      <point x="1097" y="530"/>
+      <point x="1133" y="601"/>
+      <point x="1161" y="626" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="1189" y="650"/>
+      <point x="1264" y="676"/>
+      <point x="1309" y="675" type="qcurve" smooth="yes"/>
+      <point x="1356" y="674"/>
+      <point x="1430" y="643"/>
+      <point x="1454" y="616" type="qcurve" smooth="yes"/>
+      <point x="1474" y="592"/>
+      <point x="1496" y="526"/>
+      <point x="1495" y="486" type="qcurve"/>
+      <point x="1386" y="486" type="line"/>
+      <point x="1387" y="507"/>
+      <point x="1381" y="544"/>
+      <point x="1372" y="558" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="1363" y="572"/>
+      <point x="1332" y="588"/>
+      <point x="1308" y="588" type="qcurve" smooth="yes"/>
+      <point x="1283" y="588"/>
+      <point x="1246" y="571"/>
+      <point x="1233" y="556" type="qcurve" smooth="yes"/>
+      <point x="1221" y="543"/>
+      <point x="1204" y="508"/>
+      <point x="1199" y="488" type="qcurve"/>
     </contour>
     <contour>
-      <point x="910" y="-32" type="line"/>
-      <point x="916" y="11"/>
-      <point x="952" y="82"/>
-      <point x="980" y="107" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="1008" y="131"/>
-      <point x="1083" y="157"/>
-      <point x="1128" y="156" type="qcurve" smooth="yes"/>
-      <point x="1172" y="155"/>
-      <point x="1242" y="128"/>
-      <point x="1266" y="104" type="qcurve" smooth="yes"/>
-      <point x="1290" y="79"/>
-      <point x="1315" y="10"/>
-      <point x="1314" y="-33" type="qcurve"/>
-      <point x="1205" y="-33" type="line"/>
-      <point x="1206" y="-12"/>
-      <point x="1200" y="25"/>
-      <point x="1191" y="39" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="1182" y="53"/>
-      <point x="1151" y="69"/>
-      <point x="1127" y="69" type="qcurve" smooth="yes"/>
-      <point x="1103" y="69"/>
-      <point x="1066" y="52"/>
-      <point x="1053" y="38" type="qcurve" smooth="yes"/>
-      <point x="1041" y="25"/>
-      <point x="1023" y="-11"/>
-      <point x="1018" y="-31" type="qcurve"/>
+      <point x="810" y="-32" type="line"/>
+      <point x="816" y="11"/>
+      <point x="852" y="82"/>
+      <point x="880" y="107" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="908" y="131"/>
+      <point x="983" y="157"/>
+      <point x="1028" y="156" type="qcurve" smooth="yes"/>
+      <point x="1072" y="155"/>
+      <point x="1142" y="128"/>
+      <point x="1166" y="104" type="qcurve" smooth="yes"/>
+      <point x="1190" y="79"/>
+      <point x="1215" y="10"/>
+      <point x="1214" y="-33" type="qcurve"/>
+      <point x="1105" y="-33" type="line"/>
+      <point x="1106" y="-12"/>
+      <point x="1100" y="25"/>
+      <point x="1091" y="39" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="1082" y="53"/>
+      <point x="1051" y="69"/>
+      <point x="1027" y="69" type="qcurve" smooth="yes"/>
+      <point x="1003" y="69"/>
+      <point x="966" y="52"/>
+      <point x="953" y="38" type="qcurve" smooth="yes"/>
+      <point x="941" y="25"/>
+      <point x="923" y="-11"/>
+      <point x="918" y="-31" type="qcurve"/>
     </contour>
     <contour>
-      <point x="302" y="-316" type="line"/>
-      <point x="308" y="-273"/>
-      <point x="343" y="-202"/>
-      <point x="372" y="-177" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="400" y="-153"/>
-      <point x="475" y="-127"/>
-      <point x="520" y="-128" type="qcurve" smooth="yes"/>
-      <point x="563" y="-128"/>
-      <point x="633" y="-155"/>
-      <point x="658" y="-180" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="682" y="-205"/>
-      <point x="708" y="-274"/>
-      <point x="707" y="-317" type="qcurve"/>
-      <point x="597" y="-317" type="line"/>
-      <point x="598" y="-296"/>
-      <point x="592" y="-259"/>
-      <point x="583" y="-245" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="574" y="-231"/>
-      <point x="543" y="-215"/>
-      <point x="519" y="-215" type="qcurve" smooth="yes"/>
-      <point x="495" y="-215"/>
-      <point x="458" y="-232"/>
-      <point x="444" y="-246" type="qcurve" smooth="yes"/>
-      <point x="432" y="-260"/>
-      <point x="415" y="-295"/>
-      <point x="410" y="-315" type="qcurve"/>
+      <point x="202" y="-316" type="line"/>
+      <point x="208" y="-273"/>
+      <point x="243" y="-202"/>
+      <point x="272" y="-177" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="300" y="-153"/>
+      <point x="375" y="-127"/>
+      <point x="420" y="-128" type="qcurve" smooth="yes"/>
+      <point x="463" y="-128"/>
+      <point x="533" y="-155"/>
+      <point x="558" y="-180" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="582" y="-205"/>
+      <point x="608" y="-274"/>
+      <point x="607" y="-317" type="qcurve"/>
+      <point x="497" y="-317" type="line"/>
+      <point x="498" y="-296"/>
+      <point x="492" y="-259"/>
+      <point x="483" y="-245" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="474" y="-231"/>
+      <point x="443" y="-215"/>
+      <point x="419" y="-215" type="qcurve" smooth="yes"/>
+      <point x="395" y="-215"/>
+      <point x="358" y="-232"/>
+      <point x="344" y="-246" type="qcurve" smooth="yes"/>
+      <point x="332" y="-260"/>
+      <point x="315" y="-295"/>
+      <point x="310" y="-315" type="qcurve"/>
     </contour>
     <contour>
-      <point x="-35" y="991" type="line"/>
-      <point x="-28" y="1034"/>
-      <point x="9" y="1104"/>
-      <point x="38" y="1129" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="66" y="1153"/>
-      <point x="141" y="1179"/>
-      <point x="186" y="1178" type="qcurve" smooth="yes"/>
-      <point x="227" y="1178"/>
-      <point x="294" y="1153"/>
-      <point x="319" y="1132" type="qcurve" smooth="yes"/>
-      <point x="346" y="1107"/>
-      <point x="374" y="1034"/>
-      <point x="373" y="989" type="qcurve"/>
-      <point x="264" y="989" type="line"/>
-      <point x="265" y="1010"/>
-      <point x="259" y="1047"/>
-      <point x="250" y="1061" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="241" y="1075"/>
-      <point x="210" y="1091"/>
-      <point x="186" y="1091" type="qcurve" smooth="yes"/>
-      <point x="162" y="1091"/>
-      <point x="126" y="1075"/>
-      <point x="113" y="1062" type="qcurve" smooth="yes"/>
-      <point x="100" y="1049"/>
-      <point x="83" y="1012"/>
-      <point x="77" y="991" type="qcurve"/>
+      <point x="-135" y="991" type="line"/>
+      <point x="-128" y="1034"/>
+      <point x="-91" y="1104"/>
+      <point x="-62" y="1129" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="-34" y="1153"/>
+      <point x="41" y="1179"/>
+      <point x="86" y="1178" type="qcurve" smooth="yes"/>
+      <point x="127" y="1178"/>
+      <point x="194" y="1153"/>
+      <point x="219" y="1132" type="qcurve" smooth="yes"/>
+      <point x="246" y="1107"/>
+      <point x="274" y="1034"/>
+      <point x="273" y="989" type="qcurve"/>
+      <point x="164" y="989" type="line"/>
+      <point x="165" y="1010"/>
+      <point x="159" y="1047"/>
+      <point x="150" y="1061" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="141" y="1075"/>
+      <point x="110" y="1091"/>
+      <point x="86" y="1091" type="qcurve" smooth="yes"/>
+      <point x="62" y="1091"/>
+      <point x="26" y="1075"/>
+      <point x="13" y="1062" type="qcurve" smooth="yes"/>
+      <point x="0" y="1049"/>
+      <point x="-17" y="1012"/>
+      <point x="-23" y="991" type="qcurve"/>
     </contour>
     <contour>
-      <point x="-291" y="487" type="line"/>
-      <point x="-285" y="530"/>
-      <point x="-248" y="600"/>
-      <point x="-219" y="625" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="-191" y="650"/>
-      <point x="-117" y="676"/>
-      <point x="-72" y="675" type="qcurve" smooth="yes"/>
-      <point x="-21" y="674"/>
-      <point x="57" y="638"/>
-      <point x="81" y="606" type="qcurve" smooth="yes"/>
-      <point x="98" y="582"/>
-      <point x="115" y="522"/>
-      <point x="114" y="486" type="qcurve"/>
-      <point x="5" y="486" type="line"/>
-      <point x="6" y="507"/>
-      <point x="0" y="544"/>
-      <point x="-9" y="558" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="-18" y="572"/>
-      <point x="-49" y="588"/>
-      <point x="-73" y="588" type="qcurve" smooth="yes"/>
-      <point x="-97" y="588"/>
-      <point x="-132" y="572"/>
-      <point x="-145" y="559" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="-158" y="545"/>
-      <point x="-176" y="508"/>
-      <point x="-182" y="488" type="qcurve"/>
+      <point x="-391" y="487" type="line"/>
+      <point x="-385" y="530"/>
+      <point x="-348" y="600"/>
+      <point x="-319" y="625" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="-291" y="650"/>
+      <point x="-217" y="676"/>
+      <point x="-172" y="675" type="qcurve" smooth="yes"/>
+      <point x="-121" y="674"/>
+      <point x="-43" y="638"/>
+      <point x="-19" y="606" type="qcurve" smooth="yes"/>
+      <point x="-2" y="582"/>
+      <point x="15" y="522"/>
+      <point x="14" y="486" type="qcurve"/>
+      <point x="-95" y="486" type="line"/>
+      <point x="-94" y="507"/>
+      <point x="-100" y="544"/>
+      <point x="-109" y="558" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="-118" y="572"/>
+      <point x="-149" y="588"/>
+      <point x="-173" y="588" type="qcurve" smooth="yes"/>
+      <point x="-197" y="588"/>
+      <point x="-232" y="572"/>
+      <point x="-245" y="559" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="-258" y="545"/>
+      <point x="-276" y="508"/>
+      <point x="-282" y="488" type="qcurve"/>
     </contour>
     <contour>
-      <point x="-219" y="-32" type="line"/>
-      <point x="-213" y="11"/>
-      <point x="-177" y="81"/>
-      <point x="-148" y="106" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="-120" y="131"/>
-      <point x="-46" y="157"/>
-      <point x="-1" y="156" type="qcurve" smooth="yes"/>
-      <point x="45" y="155"/>
-      <point x="119" y="125"/>
-      <point x="143" y="98" type="qcurve" smooth="yes"/>
-      <point x="165" y="74"/>
-      <point x="187" y="7"/>
-      <point x="186" y="-33" type="qcurve"/>
-      <point x="76" y="-33" type="line"/>
-      <point x="77" y="-12"/>
-      <point x="71" y="25"/>
-      <point x="62" y="39" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="53" y="53"/>
-      <point x="22" y="69"/>
-      <point x="-2" y="69" type="qcurve" smooth="yes"/>
-      <point x="-26" y="69"/>
-      <point x="-61" y="53"/>
-      <point x="-73" y="40" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="-86" y="26"/>
-      <point x="-104" y="-11"/>
-      <point x="-110" y="-31" type="qcurve"/>
+      <point x="-319" y="-32" type="line"/>
+      <point x="-313" y="11"/>
+      <point x="-277" y="81"/>
+      <point x="-248" y="106" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="-220" y="131"/>
+      <point x="-146" y="157"/>
+      <point x="-101" y="156" type="qcurve" smooth="yes"/>
+      <point x="-55" y="155"/>
+      <point x="19" y="125"/>
+      <point x="43" y="98" type="qcurve" smooth="yes"/>
+      <point x="65" y="74"/>
+      <point x="87" y="7"/>
+      <point x="86" y="-33" type="qcurve"/>
+      <point x="-24" y="-33" type="line"/>
+      <point x="-23" y="-12"/>
+      <point x="-29" y="25"/>
+      <point x="-38" y="39" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="-47" y="53"/>
+      <point x="-78" y="69"/>
+      <point x="-102" y="69" type="qcurve" smooth="yes"/>
+      <point x="-126" y="69"/>
+      <point x="-161" y="53"/>
+      <point x="-173" y="40" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="-186" y="26"/>
+      <point x="-204" y="-11"/>
+      <point x="-210" y="-31" type="qcurve"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Italic.ufo/glyphs/uni0489.glif
+++ b/sources/RobotoMono-Italic.ufo/glyphs/uni0489.glif
@@ -1,63 +1,63 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni0489" format="2">
-  <advance width="10"/>
+  <advance width="1202"/>
   <unicode hex="0489"/>
   <outline>
     <contour>
-      <point x="952" y="-58" type="line"/>
-      <point x="965" y="-76" type="line"/>
-      <point x="793" y="-413" type="line"/>
-      <point x="692" y="-413" type="line"/>
-      <point x="819" y="-61" type="line"/>
+      <point x="563" y="-58" type="line"/>
+      <point x="576" y="-76" type="line"/>
+      <point x="404" y="-413" type="line"/>
+      <point x="303" y="-413" type="line"/>
+      <point x="430" y="-61" type="line"/>
     </contour>
     <contour>
-      <point x="980" y="1125" type="line"/>
-      <point x="967" y="1141" type="line"/>
-      <point x="1138" y="1478" type="line"/>
-      <point x="1238" y="1478" type="line"/>
-      <point x="1112" y="1127" type="line"/>
+      <point x="591" y="1125" type="line"/>
+      <point x="578" y="1141" type="line"/>
+      <point x="749" y="1478" type="line"/>
+      <point x="849" y="1478" type="line"/>
+      <point x="723" y="1127" type="line"/>
     </contour>
     <contour>
-      <point x="1541" y="632" type="line"/>
-      <point x="1552" y="642" type="line"/>
-      <point x="1863" y="515" type="line"/>
-      <point x="1846" y="423" type="line"/>
-      <point x="1526" y="492" type="line"/>
+      <point x="1152" y="632" type="line"/>
+      <point x="1163" y="642" type="line"/>
+      <point x="1474" y="515" type="line"/>
+      <point x="1457" y="423" type="line"/>
+      <point x="1137" y="492" type="line"/>
     </contour>
     <contour>
-      <point x="387" y="432" type="line"/>
-      <point x="377" y="422" type="line"/>
-      <point x="66" y="549" type="line"/>
-      <point x="83" y="640" type="line"/>
-      <point x="403" y="572" type="line"/>
+      <point x="-2" y="432" type="line"/>
+      <point x="-12" y="422" type="line"/>
+      <point x="-323" y="549" type="line"/>
+      <point x="-306" y="640" type="line"/>
+      <point x="14" y="572" type="line"/>
     </contour>
     <contour>
-      <point x="1376" y="1002" type="line"/>
-      <point x="1379" y="1019" type="line"/>
-      <point x="1712" y="1172" type="line"/>
-      <point x="1773" y="1095" type="line"/>
-      <point x="1465" y="904" type="line"/>
+      <point x="987" y="1002" type="line"/>
+      <point x="990" y="1019" type="line"/>
+      <point x="1323" y="1172" type="line"/>
+      <point x="1384" y="1095" type="line"/>
+      <point x="1076" y="904" type="line"/>
     </contour>
     <contour>
-      <point x="545" y="21" type="line"/>
-      <point x="542" y="3" type="line"/>
-      <point x="211" y="-150" type="line"/>
-      <point x="149" y="-72" type="line"/>
-      <point x="457" y="119" type="line"/>
+      <point x="156" y="21" type="line"/>
+      <point x="153" y="3" type="line"/>
+      <point x="-178" y="-150" type="line"/>
+      <point x="-240" y="-72" type="line"/>
+      <point x="68" y="119" type="line"/>
     </contour>
     <contour>
-      <point x="562" y="860" type="line"/>
-      <point x="545" y="862" type="line"/>
-      <point x="452" y="1197" type="line"/>
-      <point x="519" y="1258" type="line"/>
-      <point x="667" y="955" type="line"/>
+      <point x="173" y="860" type="line"/>
+      <point x="156" y="862" type="line"/>
+      <point x="63" y="1197" type="line"/>
+      <point x="130" y="1258" type="line"/>
+      <point x="278" y="955" type="line"/>
     </contour>
     <contour>
-      <point x="1357" y="161" type="line"/>
-      <point x="1376" y="159" type="line"/>
-      <point x="1469" y="-176" type="line"/>
-      <point x="1400" y="-238" type="line"/>
-      <point x="1253" y="65" type="line"/>
+      <point x="968" y="161" type="line"/>
+      <point x="987" y="159" type="line"/>
+      <point x="1080" y="-176" type="line"/>
+      <point x="1011" y="-238" type="line"/>
+      <point x="864" y="65" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Italic.ufo/glyphs/uni049E_.glif
+++ b/sources/RobotoMono-Italic.ufo/glyphs/uni049E_.glif
@@ -1,30 +1,30 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni049E" format="2">
-  <advance width="1222"/>
+  <advance width="1202"/>
   <unicode hex="049E"/>
   <outline>
     <contour>
-      <point x="720" y="1129" type="line"/>
-      <point x="456" y="1129" type="line"/>
-      <point x="400" y="810" type="line"/>
-      <point x="544" y="810" type="line"/>
-      <point x="1086" y="1456" type="line"/>
-      <point x="1306" y="1456" type="line"/>
-      <point x="695" y="741" type="line"/>
-      <point x="1080" y="0" type="line"/>
-      <point x="872" y="0" type="line"/>
-      <point x="546" y="659" type="line"/>
-      <point x="375" y="659" type="line"/>
-      <point x="260" y="0" type="line"/>
-      <point x="79" y="0" type="line"/>
-      <point x="275" y="1129" type="line"/>
-      <point x="101" y="1129" type="line"/>
-      <point x="128" y="1280" type="line"/>
-      <point x="301" y="1280" type="line"/>
-      <point x="332" y="1456" type="line"/>
-      <point x="513" y="1456" type="line"/>
-      <point x="482" y="1280" type="line"/>
-      <point x="747" y="1280" type="line"/>
+      <point x="710" y="1129" type="line"/>
+      <point x="446" y="1129" type="line"/>
+      <point x="390" y="810" type="line"/>
+      <point x="534" y="810" type="line"/>
+      <point x="1076" y="1456" type="line"/>
+      <point x="1296" y="1456" type="line"/>
+      <point x="685" y="741" type="line"/>
+      <point x="1070" y="0" type="line"/>
+      <point x="862" y="0" type="line"/>
+      <point x="536" y="659" type="line"/>
+      <point x="365" y="659" type="line"/>
+      <point x="250" y="0" type="line"/>
+      <point x="69" y="0" type="line"/>
+      <point x="265" y="1129" type="line"/>
+      <point x="91" y="1129" type="line"/>
+      <point x="118" y="1280" type="line"/>
+      <point x="291" y="1280" type="line"/>
+      <point x="322" y="1456" type="line"/>
+      <point x="503" y="1456" type="line"/>
+      <point x="472" y="1280" type="line"/>
+      <point x="737" y="1280" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Italic.ufo/glyphs/uni049F_.glif
+++ b/sources/RobotoMono-Italic.ufo/glyphs/uni049F_.glif
@@ -1,30 +1,30 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni049F" format="2">
-  <advance width="1222"/>
+  <advance width="1202"/>
   <unicode hex="049F"/>
   <outline>
     <contour>
-      <point x="714" y="1217" type="line"/>
-      <point x="479" y="1217" type="line"/>
-      <point x="373" y="606" type="line"/>
-      <point x="506" y="729" type="line"/>
-      <point x="908" y="1082" type="line"/>
-      <point x="1144" y="1082" type="line"/>
-      <point x="630" y="622" type="line"/>
-      <point x="1006" y="0" type="line"/>
-      <point x="791" y="0" type="line"/>
-      <point x="494" y="503" type="line"/>
-      <point x="331" y="366" type="line"/>
-      <point x="268" y="0" type="line"/>
-      <point x="86" y="0" type="line"/>
-      <point x="297" y="1217" type="line"/>
-      <point x="95" y="1217" type="line"/>
-      <point x="122" y="1368" type="line"/>
-      <point x="324" y="1368" type="line"/>
-      <point x="353" y="1536" type="line"/>
-      <point x="535" y="1536" type="line"/>
-      <point x="506" y="1368" type="line"/>
-      <point x="741" y="1368" type="line"/>
+      <point x="704" y="1217" type="line"/>
+      <point x="469" y="1217" type="line"/>
+      <point x="363" y="606" type="line"/>
+      <point x="496" y="729" type="line"/>
+      <point x="898" y="1082" type="line"/>
+      <point x="1134" y="1082" type="line"/>
+      <point x="620" y="622" type="line"/>
+      <point x="996" y="0" type="line"/>
+      <point x="781" y="0" type="line"/>
+      <point x="484" y="503" type="line"/>
+      <point x="321" y="366" type="line"/>
+      <point x="258" y="0" type="line"/>
+      <point x="76" y="0" type="line"/>
+      <point x="287" y="1217" type="line"/>
+      <point x="85" y="1217" type="line"/>
+      <point x="112" y="1368" type="line"/>
+      <point x="314" y="1368" type="line"/>
+      <point x="343" y="1536" type="line"/>
+      <point x="525" y="1536" type="line"/>
+      <point x="496" y="1368" type="line"/>
+      <point x="731" y="1368" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Italic.ufo/glyphs/uni20A_B_.glif
+++ b/sources/RobotoMono-Italic.ufo/glyphs/uni20A_B_.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni20AB" format="2">
-  <advance width="1232"/>
+  <advance width="1202"/>
   <unicode hex="20AB"/>
   <outline>
-    <component base="d"/>
-    <component base="crossbar" xOffset="395" yOffset="583"/>
-    <component base="underscore" xOffset="24" yOffset="-124"/>
+    <component base="d" xOffset="-15"/>
+    <component base="crossbar" xOffset="380" yOffset="583"/>
+    <component base="underscore" xOffset="9" yOffset="-124"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Italic.ufo/glyphs/uniF_F_F_D_.glif
+++ b/sources/RobotoMono-Italic.ufo/glyphs/uniF_F_F_D_.glif
@@ -1,77 +1,77 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uniFFFD" format="2">
-  <advance width="1229"/>
+  <advance width="1202"/>
   <unicode hex="FFFD"/>
   <outline>
     <contour>
-      <point x="610" y="1618" type="line"/>
-      <point x="1199" y="643" type="line"/>
-      <point x="610" y="-332" type="line"/>
-      <point x="15" y="643" type="line"/>
+      <point x="596" y="1618" type="line"/>
+      <point x="1185" y="643" type="line"/>
+      <point x="596" y="-332" type="line"/>
+      <point x="1" y="643" type="line"/>
     </contour>
     <contour>
-      <point x="713" y="392" type="line"/>
-      <point x="713" y="417"/>
-      <point x="719" y="456"/>
-      <point x="725.0" y="471.5" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="731" y="487"/>
-      <point x="748" y="516"/>
-      <point x="759" y="532" type="qcurve" smooth="yes"/>
-      <point x="781" y="563"/>
-      <point x="826" y="618"/>
-      <point x="844.0" y="646.5" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="862" y="675"/>
-      <point x="885" y="739"/>
-      <point x="885" y="780" type="qcurve" smooth="yes"/>
-      <point x="885" y="844"/>
-      <point x="848" y="947"/>
-      <point x="813.5" y="983.5" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="779" y="1020"/>
-      <point x="677" y="1059"/>
-      <point x="613" y="1059" type="qcurve" smooth="yes"/>
-      <point x="557" y="1059"/>
-      <point x="460" y="1029"/>
-      <point x="423.5" y="996.5" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="387" y="964"/>
-      <point x="344" y="863"/>
-      <point x="343" y="793" type="qcurve"/>
-      <point x="546" y="793" type="line"/>
-      <point x="548" y="848"/>
-      <point x="589" y="896"/>
-      <point x="613" y="896" type="qcurve" smooth="yes"/>
-      <point x="650" y="896"/>
-      <point x="682" y="832"/>
-      <point x="682" y="780" type="qcurve" smooth="yes"/>
-      <point x="682" y="754"/>
-      <point x="665" y="703"/>
-      <point x="653.0" y="679.5" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="641" y="656"/>
-      <point x="614" y="617"/>
-      <point x="604" y="604" type="qcurve" smooth="yes"/>
-      <point x="575" y="568"/>
-      <point x="540" y="528"/>
-      <point x="529.5" y="509.0" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="519" y="490"/>
-      <point x="511" y="440"/>
-      <point x="511" y="392" type="qcurve"/>
+      <point x="699" y="392" type="line"/>
+      <point x="699" y="417"/>
+      <point x="705" y="456"/>
+      <point x="711.0" y="472" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="717" y="487"/>
+      <point x="734" y="516"/>
+      <point x="745" y="532" type="qcurve" smooth="yes"/>
+      <point x="767" y="563"/>
+      <point x="812" y="618"/>
+      <point x="830.0" y="647" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="848" y="675"/>
+      <point x="871" y="739"/>
+      <point x="871" y="780" type="qcurve" smooth="yes"/>
+      <point x="871" y="844"/>
+      <point x="834" y="947"/>
+      <point x="800" y="984" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="765" y="1020"/>
+      <point x="663" y="1059"/>
+      <point x="599" y="1059" type="qcurve" smooth="yes"/>
+      <point x="543" y="1059"/>
+      <point x="446" y="1029"/>
+      <point x="410" y="997" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="373" y="964"/>
+      <point x="330" y="863"/>
+      <point x="329" y="793" type="qcurve"/>
+      <point x="532" y="793" type="line"/>
+      <point x="534" y="848"/>
+      <point x="575" y="896"/>
+      <point x="599" y="896" type="qcurve" smooth="yes"/>
+      <point x="636" y="896"/>
+      <point x="668" y="832"/>
+      <point x="668" y="780" type="qcurve" smooth="yes"/>
+      <point x="668" y="754"/>
+      <point x="651" y="703"/>
+      <point x="639.0" y="680" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="627" y="656"/>
+      <point x="600" y="617"/>
+      <point x="590" y="604" type="qcurve" smooth="yes"/>
+      <point x="561" y="568"/>
+      <point x="526" y="528"/>
+      <point x="516" y="509.0" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="505" y="490"/>
+      <point x="497" y="440"/>
+      <point x="497" y="392" type="qcurve"/>
     </contour>
     <contour>
-      <point x="713" y="301" type="line"/>
-      <point x="511" y="301" type="line"/>
-      <point x="511" y="131" type="line"/>
-      <point x="713" y="131" type="line"/>
+      <point x="699" y="301" type="line"/>
+      <point x="497" y="301" type="line"/>
+      <point x="497" y="131" type="line"/>
+      <point x="699" y="131" type="line"/>
     </contour>
     <contour>
-      <point x="605" y="-551" type="line"/>
-      <point x="609" y="-551" type="line"/>
-      <point x="609" y="-555" type="line"/>
-      <point x="605" y="-555" type="line"/>
+      <point x="591" y="-551" type="line"/>
+      <point x="595" y="-551" type="line"/>
+      <point x="595" y="-555" type="line"/>
+      <point x="591" y="-555" type="line"/>
     </contour>
     <contour>
-      <point x="603" y="2163" type="line"/>
-      <point x="607" y="2163" type="line"/>
-      <point x="607" y="2159" type="line"/>
-      <point x="603" y="2159" type="line"/>
+      <point x="589" y="2163" type="line"/>
+      <point x="593" y="2163" type="line"/>
+      <point x="593" y="2159" type="line"/>
+      <point x="589" y="2159" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Italic.ufo/lib.plist
+++ b/sources/RobotoMono-Italic.ufo/lib.plist
@@ -2,6 +2,17 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
   <dict>
+    <key>com.defcon.sortDescriptor</key>
+    <array>
+      <dict>
+        <key>allowPseudoUnicode</key>
+        <integer>0</integer>
+        <key>ascending</key>
+        <string>Amstelvar DB Best</string>
+        <key>type</key>
+        <string>characterSet</string>
+      </dict>
+    </array>
     <key>com.typemytype.robofont.binarySource</key>
     <string>/Users/pichotta/Downloads/Roboto_Mono_Italics/RobotoMono-Italic.ttf</string>
     <key>com.typemytype.robofont.compileSettings.autohint</key>
@@ -26,41 +37,8 @@
     <integer>1</integer>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
       <string>NULL</string>
-      <string>nonmarkingreturn</string>
       <string>space</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
       <string>B</string>
       <string>C</string>
@@ -87,12 +65,6 @@
       <string>X</string>
       <string>Y</string>
       <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
       <string>a</string>
       <string>b</string>
       <string>c</string>
@@ -119,84 +91,329 @@
       <string>x</string>
       <string>y</string>
       <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemotleft</string>
-      <string>logicalnot</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
+      <string>onesuperior</string>
       <string>twosuperior</string>
       <string>threesuperior</string>
-      <string>acute</string>
-      <string>mu</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
+      <string>ordfeminine</string>
       <string>ordmasculine</string>
-      <string>guillemotright</string>
-      <string>onequarter</string>
       <string>onehalf</string>
+      <string>onequarter</string>
       <string>threequarters</string>
-      <string>questiondown</string>
       <string>AE</string>
-      <string>multiply</string>
-      <string>Oslash</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
       <string>ae</string>
+      <string>OE</string>
+      <string>oe</string>
       <string>eth</string>
-      <string>divide</string>
-      <string>oslash</string>
+      <string>Thorn</string>
       <string>thorn</string>
+      <string>kgreenlandic</string>
+      <string>germandbls</string>
+      <string>schwa</string>
+      <string>dollar</string>
+      <string>cent</string>
+      <string>sterling</string>
+      <string>yen</string>
+      <string>florin</string>
+      <string>franc</string>
+      <string>lira</string>
+      <string>peseta</string>
+      <string>currency</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>comma</string>
+      <string>period</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>ellipsis</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>underscore</string>
+      <string>hyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>quotesingle</string>
+      <string>quotedbl</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quotedblbase</string>
+      <string>minute</string>
+      <string>second</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>plusminus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>approxequal</string>
+      <string>less</string>
+      <string>greater</string>
+      <string>lessequal</string>
+      <string>greaterequal</string>
+      <string>logicalnot</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>fraction</string>
+      <string>percent</string>
+      <string>perthousand</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>dagger</string>
+      <string>daggerdbl</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>ampersand</string>
+      <string>at</string>
+      <string>section</string>
+      <string>paragraph</string>
+      <string>asciicircum</string>
+      <string>asciitilde</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Acircumflex</string>
+      <string>Adieresis</string>
+      <string>Agrave</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Aringacute</string>
+      <string>Atilde</string>
+      <string>AEacute</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Ccircumflex</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Eacute</string>
+      <string>Ebreve</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Egrave</string>
+      <string>Emacron</string>
+      <string>Eng</string>
+      <string>Eogonek</string>
+      <string>Eth</string>
+      <string>Gbreve</string>
+      <string>Gcircumflex</string>
+      <string>Gcommaaccent</string>
       <string>Hbar</string>
+      <string>Hcircumflex</string>
+      <string>Iacute</string>
+      <string>Ibreve</string>
+      <string>Icircumflex</string>
+      <string>Idieresis</string>
+      <string>Idotaccent</string>
+      <string>Igrave</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>Jcircumflex</string>
+      <string>Kcommaaccent</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ntilde</string>
+      <string>Oacute</string>
+      <string>Obreve</string>
+      <string>Ocircumflex</string>
+      <string>Odieresis</string>
+      <string>Ograve</string>
+      <string>Ohorn</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
+      <string>Oslash</string>
+      <string>Oslashacute</string>
+      <string>Otilde</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scircumflex</string>
+      <string>Tbar</string>
+      <string>Tcaron</string>
+      <string>Uacute</string>
+      <string>Ubreve</string>
+      <string>Ucircumflex</string>
+      <string>Udieresis</string>
+      <string>Ugrave</string>
+      <string>Uhorn</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>Yacute</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ygrave</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>aacute</string>
+      <string>abreve</string>
+      <string>acircumflex</string>
+      <string>adieresis</string>
+      <string>agrave</string>
+      <string>amacron</string>
+      <string>aogonek</string>
+      <string>aring</string>
+      <string>aringacute</string>
+      <string>atilde</string>
+      <string>aeacute</string>
+      <string>cacute</string>
+      <string>ccaron</string>
+      <string>ccedilla</string>
+      <string>ccircumflex</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>eacute</string>
+      <string>ebreve</string>
+      <string>ecaron</string>
+      <string>ecircumflex</string>
+      <string>edieresis</string>
+      <string>edotaccent</string>
+      <string>egrave</string>
+      <string>emacron</string>
+      <string>eng</string>
+      <string>eogonek</string>
+      <string>gbreve</string>
+      <string>gcircumflex</string>
+      <string>gcommaaccent</string>
+      <string>hbar</string>
+      <string>hcircumflex</string>
+      <string>iacute</string>
+      <string>ibreve</string>
+      <string>icircumflex</string>
+      <string>idieresis</string>
+      <string>igrave</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>jcircumflex</string>
+      <string>kcommaaccent</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ntilde</string>
+      <string>oacute</string>
+      <string>obreve</string>
+      <string>ocircumflex</string>
+      <string>odieresis</string>
+      <string>ograve</string>
+      <string>ohorn</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
+      <string>oslash</string>
+      <string>oslashacute</string>
+      <string>otilde</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scircumflex</string>
+      <string>tbar</string>
+      <string>tcaron</string>
+      <string>uacute</string>
+      <string>ubreve</string>
+      <string>ucircumflex</string>
+      <string>udieresis</string>
+      <string>ugrave</string>
+      <string>uhorn</string>
+      <string>uhungarumlaut</string>
+      <string>umacron</string>
+      <string>uogonek</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>wacute</string>
+      <string>wcircumflex</string>
+      <string>wdieresis</string>
+      <string>wgrave</string>
+      <string>yacute</string>
+      <string>ycircumflex</string>
+      <string>ydieresis</string>
+      <string>ygrave</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>circumflex</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>breve</string>
+      <string>dotaccent</string>
+      <string>dieresis</string>
+      <string>ring</string>
+      <string>hungarumlaut</string>
+      <string>caron</string>
+      <string>dotbelow</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
+      <string>commaaccent</string>
+      <string>.notdef</string>
+      <string>nonmarkingreturn</string>
+      <string>guillemotleft</string>
+      <string>mu</string>
+      <string>guillemotright</string>
       <string>dotlessi</string>
       <string>IJ</string>
       <string>ij</string>
-      <string>kgreenlandic</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Eng</string>
-      <string>eng</string>
-      <string>OE</string>
-      <string>oe</string>
       <string>longs</string>
-      <string>florin</string>
-      <string>Ohorn</string>
-      <string>ohorn</string>
-      <string>Uhorn</string>
-      <string>uhorn</string>
       <string>uni0237</string>
-      <string>schwa</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
       <string>uni02F3</string>
       <string>gravecomb</string>
       <string>acutecomb</string>
       <string>tildecomb</string>
       <string>hook</string>
       <string>uni030F</string>
-      <string>dotbelow</string>
       <string>tonos</string>
       <string>dieresistonos</string>
       <string>anoteleia</string>
@@ -382,34 +599,15 @@
       <string>uni2009</string>
       <string>uni200A</string>
       <string>uni200B</string>
-      <string>endash</string>
-      <string>emdash</string>
       <string>underscoredbl</string>
-      <string>quoteleft</string>
-      <string>quoteright</string>
-      <string>quotesinglbase</string>
       <string>quotereversed</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>quotedblbase</string>
-      <string>dagger</string>
-      <string>daggerdbl</string>
-      <string>bullet</string>
       <string>uni2025</string>
-      <string>ellipsis</string>
-      <string>perthousand</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
       <string>uni2074</string>
       <string>nsuperior</string>
-      <string>lira</string>
-      <string>peseta</string>
       <string>Euro</string>
       <string>uni2105</string>
       <string>uni2113</string>
       <string>uni2116</string>
-      <string>trademark</string>
       <string>estimated</string>
       <string>oneeighth</string>
       <string>threeeighths</string>
@@ -418,16 +616,10 @@
       <string>partialdiff</string>
       <string>product</string>
       <string>summation</string>
-      <string>minus</string>
       <string>radical</string>
       <string>infinity</string>
       <string>integral</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>lessequal</string>
-      <string>greaterequal</string>
       <string>lozenge</string>
-      <string>commaaccent</string>
       <string>uniFEFF</string>
       <string>uniFFFC</string>
       <string>uniFFFD</string>
@@ -482,186 +674,18 @@
       <string>Germandbls.smcp</string>
       <string>nonbreakingspace</string>
       <string>uni00AD</string>
-      <string>Dcroat</string>
-      <string>Eth</string>
-      <string>hbar</string>
-      <string>Tbar</string>
-      <string>tbar</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>Aringacute</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
-      <string>Iacute</string>
-      <string>Icircumflex</string>
-      <string>Idieresis</string>
-      <string>Ntilde</string>
-      <string>Ograve</string>
-      <string>Oacute</string>
-      <string>Ocircumflex</string>
-      <string>Otilde</string>
-      <string>Odieresis</string>
-      <string>Ugrave</string>
-      <string>Uacute</string>
-      <string>Ucircumflex</string>
-      <string>Udieresis</string>
-      <string>Yacute</string>
-      <string>agrave</string>
-      <string>aacute</string>
-      <string>acircumflex</string>
-      <string>atilde</string>
-      <string>adieresis</string>
-      <string>aring</string>
-      <string>aringacute</string>
-      <string>ccedilla</string>
-      <string>egrave</string>
-      <string>eacute</string>
-      <string>ecircumflex</string>
-      <string>edieresis</string>
-      <string>igrave</string>
-      <string>iacute</string>
-      <string>icircumflex</string>
-      <string>idieresis</string>
-      <string>ntilde</string>
-      <string>ograve</string>
-      <string>oacute</string>
-      <string>ocircumflex</string>
-      <string>otilde</string>
-      <string>odieresis</string>
-      <string>ugrave</string>
-      <string>uacute</string>
-      <string>ucircumflex</string>
-      <string>udieresis</string>
-      <string>yacute</string>
-      <string>ydieresis</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Ccircumflex</string>
-      <string>ccircumflex</string>
       <string>uni010A</string>
       <string>uni010B</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Ebreve</string>
-      <string>ebreve</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Gcircumflex</string>
-      <string>gcircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
       <string>uni0120</string>
       <string>uni0121</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Hcircumflex</string>
-      <string>hcircumflex</string>
-      <string>Itilde</string>
-      <string>itilde</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Ibreve</string>
-      <string>ibreve</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Idotaccent</string>
-      <string>Jcircumflex</string>
-      <string>jcircumflex</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
       <string>napostrophe</string>
-      <string>Omacron</string>
-      <string>omacron</string>
-      <string>Obreve</string>
-      <string>obreve</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Rcommaaccent</string>
-      <string>rcommaaccent</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Scircumflex</string>
-      <string>scircumflex</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
       <string>uni0218</string>
       <string>uni0219</string>
-      <string>Scaron</string>
-      <string>scaron</string>
       <string>uni021A</string>
       <string>uni021B</string>
       <string>uni0162</string>
       <string>uni0162.smcp</string>
       <string>uni0163</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Utilde</string>
-      <string>utilde</string>
-      <string>Umacron</string>
-      <string>umacron</string>
-      <string>Ubreve</string>
-      <string>ubreve</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Uhungarumlaut</string>
-      <string>uhungarumlaut</string>
-      <string>Uogonek</string>
-      <string>uogonek</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Ycircumflex</string>
-      <string>ycircumflex</string>
-      <string>Ydieresis</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>AEacute</string>
-      <string>aeacute</string>
-      <string>Oslashacute</string>
-      <string>oslashacute</string>
       <string>Dcroat.smcp</string>
       <string>Eth.smcp</string>
       <string>Tbar.smcp</string>
@@ -823,16 +847,6 @@
       <string>uni0458</string>
       <string>uni045C</string>
       <string>uni045E</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
-      <string>wacute</string>
-      <string>Wdieresis</string>
-      <string>wdieresis</string>
-      <string>Ygrave</string>
-      <string>ygrave</string>
-      <string>minute</string>
-      <string>second</string>
       <string>exclamdbl</string>
       <string>uni01F0</string>
       <string>uni02BC</string>
@@ -989,7 +1003,6 @@
       <string>uni1EF7</string>
       <string>uni1EF8</string>
       <string>uni1EF9</string>
-      <string>dcroat</string>
       <string>uni20AB</string>
       <string>uni049A</string>
       <string>uni049B</string>
@@ -1030,11 +1043,9 @@
       <string>uni04FE</string>
       <string>uni04FF</string>
       <string>uni0511</string>
-      <string>franc</string>
       <string>uni2015</string>
       <string>uni0002</string>
       <string>uni0009</string>
-      <string>exclam</string>
     </array>
   </dict>
 </plist>

--- a/sources/RobotoMono-Regular.ufo/glyphs/D_croat.glif
+++ b/sources/RobotoMono-Regular.ufo/glyphs/D_croat.glif
@@ -1,51 +1,51 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Dcroat" format="2">
-  <advance width="1259"/>
+  <advance width="1229"/>
   <unicode hex="0110"/>
   <outline>
     <contour>
-      <point x="185" y="0" type="line"/>
-      <point x="185" y="666" type="line"/>
-      <point x="-44" y="666" type="line"/>
-      <point x="-44" y="817" type="line"/>
-      <point x="185" y="817" type="line"/>
-      <point x="185" y="1456" type="line"/>
-      <point x="522" y="1456" type="line" smooth="yes"/>
-      <point x="674" y="1454"/>
-      <point x="913" y="1355"/>
-      <point x="995.5" y="1266.5" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="1078" y="1178"/>
-      <point x="1165" y="931"/>
-      <point x="1166" y="781" type="qcurve" smooth="yes"/>
-      <point x="1166" y="674" type="line"/>
-      <point x="1165" y="524"/>
-      <point x="1078" y="277"/>
-      <point x="995.5" y="188.5" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="913" y="100"/>
-      <point x="674" y="1"/>
-      <point x="522" y="0" type="qcurve" smooth="yes"/>
+      <point x="170" y="0" type="line"/>
+      <point x="170" y="666" type="line"/>
+      <point x="-59" y="666" type="line"/>
+      <point x="-59" y="817" type="line"/>
+      <point x="170" y="817" type="line"/>
+      <point x="170" y="1456" type="line"/>
+      <point x="507" y="1456" type="line" smooth="yes"/>
+      <point x="659" y="1454"/>
+      <point x="898" y="1355"/>
+      <point x="981" y="1267" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="1063" y="1178"/>
+      <point x="1150" y="931"/>
+      <point x="1151" y="781" type="qcurve" smooth="yes"/>
+      <point x="1151" y="674" type="line"/>
+      <point x="1150" y="524"/>
+      <point x="1063" y="277"/>
+      <point x="981" y="189" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="898" y="100"/>
+      <point x="659" y="1"/>
+      <point x="507" y="0" type="qcurve" smooth="yes"/>
     </contour>
     <contour>
-      <point x="593" y="666" type="line"/>
-      <point x="373" y="666" type="line"/>
-      <point x="373" y="151" type="line"/>
-      <point x="522" y="151" type="line" smooth="yes"/>
-      <point x="640" y="152"/>
-      <point x="812" y="233"/>
-      <point x="868.5" y="303.0" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="925" y="373"/>
-      <point x="980" y="563"/>
-      <point x="981" y="674" type="qcurve" smooth="yes"/>
-      <point x="981" y="783" type="line" smooth="yes"/>
-      <point x="980" y="894"/>
-      <point x="924" y="1083"/>
-      <point x="868.0" y="1152.5" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="812" y="1222"/>
-      <point x="640" y="1302"/>
-      <point x="522" y="1304" type="qcurve" smooth="yes"/>
-      <point x="373" y="1304" type="line"/>
-      <point x="373" y="817" type="line"/>
-      <point x="593" y="817" type="line"/>
+      <point x="578" y="666" type="line"/>
+      <point x="358" y="666" type="line"/>
+      <point x="358" y="151" type="line"/>
+      <point x="507" y="151" type="line" smooth="yes"/>
+      <point x="625" y="152"/>
+      <point x="797" y="233"/>
+      <point x="854" y="303.0" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="910" y="373"/>
+      <point x="965" y="563"/>
+      <point x="966" y="674" type="qcurve" smooth="yes"/>
+      <point x="966" y="783" type="line" smooth="yes"/>
+      <point x="965" y="894"/>
+      <point x="909" y="1083"/>
+      <point x="853.0" y="1153" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="797" y="1222"/>
+      <point x="625" y="1302"/>
+      <point x="507" y="1304" type="qcurve" smooth="yes"/>
+      <point x="358" y="1304" type="line"/>
+      <point x="358" y="817" type="line"/>
+      <point x="578" y="817" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Regular.ufo/glyphs/E_psilontonos.glif
+++ b/sources/RobotoMono-Regular.ufo/glyphs/E_psilontonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Epsilontonos" format="2">
-  <advance width="1329"/>
+  <advance width="1229"/>
   <unicode hex="0388"/>
   <outline>
-    <component base="E" xOffset="100"/>
-    <component base="tonos" xOffset="-538"/>
+    <component base="E" xOffset="50"/>
+    <component base="tonos" xOffset="-588"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Regular.ufo/glyphs/E_tatonos.glif
+++ b/sources/RobotoMono-Regular.ufo/glyphs/E_tatonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etatonos" format="2">
-  <advance width="1329"/>
+  <advance width="1229"/>
   <unicode hex="0389"/>
   <outline>
-    <component base="H" xOffset="100"/>
-    <component base="tonos" xOffset="-556" yOffset="2"/>
+    <component base="H" xOffset="50"/>
+    <component base="tonos" xOffset="-606" yOffset="2"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Regular.ufo/glyphs/E_th.glif
+++ b/sources/RobotoMono-Regular.ufo/glyphs/E_th.glif
@@ -1,51 +1,51 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Eth" format="2">
-  <advance width="1259"/>
+  <advance width="1229"/>
   <unicode hex="00D0"/>
   <outline>
     <contour>
-      <point x="185" y="0" type="line"/>
-      <point x="185" y="666" type="line"/>
-      <point x="-44" y="666" type="line"/>
-      <point x="-44" y="817" type="line"/>
-      <point x="185" y="817" type="line"/>
-      <point x="185" y="1456" type="line"/>
-      <point x="522" y="1456" type="line" smooth="yes"/>
-      <point x="674" y="1454"/>
-      <point x="913" y="1355"/>
-      <point x="995.5" y="1266.5" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="1078" y="1178"/>
-      <point x="1165" y="931"/>
-      <point x="1166" y="781" type="qcurve" smooth="yes"/>
-      <point x="1166" y="674" type="line"/>
-      <point x="1165" y="524"/>
-      <point x="1078" y="277"/>
-      <point x="995.5" y="188.5" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="913" y="100"/>
-      <point x="674" y="1"/>
-      <point x="522" y="0" type="qcurve" smooth="yes"/>
+      <point x="170" y="0" type="line"/>
+      <point x="170" y="666" type="line"/>
+      <point x="-59" y="666" type="line"/>
+      <point x="-59" y="817" type="line"/>
+      <point x="170" y="817" type="line"/>
+      <point x="170" y="1456" type="line"/>
+      <point x="507" y="1456" type="line" smooth="yes"/>
+      <point x="659" y="1454"/>
+      <point x="898" y="1355"/>
+      <point x="981" y="1267" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="1063" y="1178"/>
+      <point x="1150" y="931"/>
+      <point x="1151" y="781" type="qcurve" smooth="yes"/>
+      <point x="1151" y="674" type="line"/>
+      <point x="1150" y="524"/>
+      <point x="1063" y="277"/>
+      <point x="981" y="189" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="898" y="100"/>
+      <point x="659" y="1"/>
+      <point x="507" y="0" type="qcurve" smooth="yes"/>
     </contour>
     <contour>
-      <point x="593" y="666" type="line"/>
-      <point x="373" y="666" type="line"/>
-      <point x="373" y="151" type="line"/>
-      <point x="522" y="151" type="line" smooth="yes"/>
-      <point x="640" y="152"/>
-      <point x="812" y="233"/>
-      <point x="868.5" y="303.0" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="925" y="373"/>
-      <point x="980" y="563"/>
-      <point x="981" y="674" type="qcurve" smooth="yes"/>
-      <point x="981" y="783" type="line" smooth="yes"/>
-      <point x="980" y="894"/>
-      <point x="924" y="1083"/>
-      <point x="868.0" y="1152.5" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="812" y="1222"/>
-      <point x="640" y="1302"/>
-      <point x="522" y="1304" type="qcurve" smooth="yes"/>
-      <point x="373" y="1304" type="line"/>
-      <point x="373" y="817" type="line"/>
-      <point x="593" y="817" type="line"/>
+      <point x="578" y="666" type="line"/>
+      <point x="358" y="666" type="line"/>
+      <point x="358" y="151" type="line"/>
+      <point x="507" y="151" type="line" smooth="yes"/>
+      <point x="625" y="152"/>
+      <point x="797" y="233"/>
+      <point x="854" y="303.0" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="910" y="373"/>
+      <point x="965" y="563"/>
+      <point x="966" y="674" type="qcurve" smooth="yes"/>
+      <point x="966" y="783" type="line" smooth="yes"/>
+      <point x="965" y="894"/>
+      <point x="909" y="1083"/>
+      <point x="853.0" y="1153" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="797" y="1222"/>
+      <point x="625" y="1302"/>
+      <point x="507" y="1304" type="qcurve" smooth="yes"/>
+      <point x="358" y="1304" type="line"/>
+      <point x="358" y="817" type="line"/>
+      <point x="578" y="817" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Regular.ufo/glyphs/I_otatonos.glif
+++ b/sources/RobotoMono-Regular.ufo/glyphs/I_otatonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Iotatonos" format="2">
-  <advance width="1329"/>
+  <advance width="1229"/>
   <unicode hex="038A"/>
   <outline>
-    <component base="I" xOffset="100"/>
-    <component base="tonos" xOffset="-573" yOffset="2"/>
+    <component base="I" xOffset="50"/>
+    <component base="tonos" xOffset="-623" yOffset="1"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Regular.ufo/glyphs/O_megatonos.glif
+++ b/sources/RobotoMono-Regular.ufo/glyphs/O_megatonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegatonos" format="2">
-  <advance width="1249"/>
+  <advance width="1229"/>
   <unicode hex="038F"/>
   <outline>
-    <component base="Omega" xOffset="20"/>
-    <component base="tonos" xOffset="-548"/>
+    <component base="Omega" xOffset="10"/>
+    <component base="tonos" xOffset="-558"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Regular.ufo/glyphs/O_microntonos.glif
+++ b/sources/RobotoMono-Regular.ufo/glyphs/O_microntonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omicrontonos" format="2">
-  <advance width="1249"/>
+  <advance width="1229"/>
   <unicode hex="038C"/>
   <outline>
-    <component base="O" xOffset="20"/>
-    <component base="tonos" xOffset="-544"/>
+    <component base="O" xOffset="10"/>
+    <component base="tonos" xOffset="-554"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Regular.ufo/glyphs/U_psilontonos.glif
+++ b/sources/RobotoMono-Regular.ufo/glyphs/U_psilontonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Upsilontonos" format="2">
-  <advance width="1329"/>
+  <advance width="1229"/>
   <unicode hex="038E"/>
   <outline>
-    <component base="Y" xOffset="100"/>
-    <component base="tonos" xOffset="-631"/>
+    <component base="Y" xOffset="50"/>
+    <component base="tonos" xOffset="-681"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Regular.ufo/glyphs/acutecomb.glif
+++ b/sources/RobotoMono-Regular.ufo/glyphs/acutecomb.glif
@@ -1,6 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="acutecomb" format="2">
-  <advance width="1106"/>
   <unicode hex="0301"/>
   <outline>
     <contour>

--- a/sources/RobotoMono-Regular.ufo/glyphs/dcaron.glif
+++ b/sources/RobotoMono-Regular.ufo/glyphs/dcaron.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="dcaron" format="2">
-  <advance width="1379"/>
+  <advance width="1229"/>
   <unicode hex="010F"/>
   <outline>
-    <component base="d"/>
-    <component base="quoteright" xOffset="774" yOffset="-1"/>
+    <component base="d" xOffset="-39"/>
+    <component base="quoteright" xOffset="735"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Regular.ufo/glyphs/dcroat.glif
+++ b/sources/RobotoMono-Regular.ufo/glyphs/dcroat.glif
@@ -1,75 +1,75 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="dcroat" format="2">
-  <advance width="1259"/>
+  <advance width="1229"/>
   <unicode hex="0111"/>
   <outline>
     <contour>
-      <point x="1249" y="1234" type="line"/>
-      <point x="1052" y="1234" type="line"/>
-      <point x="1052" y="0" type="line"/>
-      <point x="882" y="0" type="line"/>
-      <point x="874" y="114" type="line"/>
-      <point x="850" y="84"/>
-      <point x="793" y="38"/>
-      <point x="760" y="21" type="qcurve" smooth="yes"/>
-      <point x="720" y="1"/>
-      <point x="625" y="-20"/>
-      <point x="570" y="-20" type="qcurve" smooth="yes"/>
-      <point x="472" y="-20"/>
-      <point x="313" y="64"/>
-      <point x="257" y="138" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="201" y="212"/>
-      <point x="139" y="413"/>
-      <point x="139" y="529" type="qcurve" smooth="yes"/>
-      <point x="139" y="550" type="line" smooth="yes"/>
-      <point x="139" y="671"/>
-      <point x="200" y="874"/>
-      <point x="257" y="947" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="313" y="1020"/>
-      <point x="473" y="1102"/>
-      <point x="572" y="1102" type="qcurve" smooth="yes"/>
-      <point x="632" y="1102"/>
-      <point x="734" y="1077"/>
-      <point x="776" y="1052" type="qcurve" smooth="yes"/>
-      <point x="802" y="1037"/>
-      <point x="847" y="998"/>
-      <point x="867" y="975" type="qcurve"/>
-      <point x="867" y="1234" type="line"/>
-      <point x="612" y="1234" type="line"/>
-      <point x="612" y="1385" type="line"/>
-      <point x="867" y="1385" type="line"/>
-      <point x="867" y="1536" type="line"/>
-      <point x="1052" y="1536" type="line"/>
-      <point x="1052" y="1385" type="line"/>
-      <point x="1249" y="1385" type="line"/>
+      <point x="1234" y="1234" type="line"/>
+      <point x="1037" y="1234" type="line"/>
+      <point x="1037" y="0" type="line"/>
+      <point x="867" y="0" type="line"/>
+      <point x="859" y="114" type="line"/>
+      <point x="835" y="84"/>
+      <point x="778" y="38"/>
+      <point x="745" y="21" type="qcurve" smooth="yes"/>
+      <point x="705" y="1"/>
+      <point x="610" y="-20"/>
+      <point x="555" y="-20" type="qcurve" smooth="yes"/>
+      <point x="457" y="-20"/>
+      <point x="298" y="64"/>
+      <point x="242" y="138" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="186" y="212"/>
+      <point x="124" y="413"/>
+      <point x="124" y="529" type="qcurve" smooth="yes"/>
+      <point x="124" y="550" type="line" smooth="yes"/>
+      <point x="124" y="671"/>
+      <point x="185" y="874"/>
+      <point x="242" y="947" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="298" y="1020"/>
+      <point x="458" y="1102"/>
+      <point x="557" y="1102" type="qcurve" smooth="yes"/>
+      <point x="617" y="1102"/>
+      <point x="719" y="1077"/>
+      <point x="761" y="1052" type="qcurve" smooth="yes"/>
+      <point x="787" y="1037"/>
+      <point x="832" y="998"/>
+      <point x="852" y="975" type="qcurve"/>
+      <point x="852" y="1234" type="line"/>
+      <point x="597" y="1234" type="line"/>
+      <point x="597" y="1385" type="line"/>
+      <point x="852" y="1385" type="line"/>
+      <point x="852" y="1536" type="line"/>
+      <point x="1037" y="1536" type="line"/>
+      <point x="1037" y="1385" type="line"/>
+      <point x="1234" y="1385" type="line"/>
     </contour>
     <contour>
-      <point x="324" y="529" type="line" smooth="yes"/>
-      <point x="324" y="450"/>
-      <point x="358" y="308"/>
-      <point x="394" y="254" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="429" y="200"/>
-      <point x="539" y="137"/>
-      <point x="616" y="137" type="qcurve" smooth="yes"/>
-      <point x="663" y="137"/>
-      <point x="739" y="159"/>
-      <point x="770" y="180" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="801" y="200"/>
-      <point x="849" y="257"/>
-      <point x="867" y="292" type="qcurve"/>
-      <point x="867" y="794" type="line"/>
-      <point x="847" y="830"/>
-      <point x="793" y="890"/>
-      <point x="759" y="910" type="qcurve" smooth="yes"/>
-      <point x="730" y="926"/>
-      <point x="659" y="945"/>
-      <point x="618" y="945" type="qcurve" smooth="yes"/>
-      <point x="540" y="945"/>
-      <point x="429" y="881"/>
-      <point x="394" y="827" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="358" y="772"/>
-      <point x="324" y="629"/>
-      <point x="324" y="550" type="qcurve" smooth="yes"/>
+      <point x="309" y="529" type="line" smooth="yes"/>
+      <point x="309" y="450"/>
+      <point x="343" y="308"/>
+      <point x="379" y="254" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="414" y="200"/>
+      <point x="524" y="137"/>
+      <point x="601" y="137" type="qcurve" smooth="yes"/>
+      <point x="648" y="137"/>
+      <point x="724" y="159"/>
+      <point x="755" y="180" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="786" y="200"/>
+      <point x="834" y="257"/>
+      <point x="852" y="292" type="qcurve"/>
+      <point x="852" y="794" type="line"/>
+      <point x="832" y="830"/>
+      <point x="778" y="890"/>
+      <point x="744" y="910" type="qcurve" smooth="yes"/>
+      <point x="715" y="926"/>
+      <point x="644" y="945"/>
+      <point x="603" y="945" type="qcurve" smooth="yes"/>
+      <point x="525" y="945"/>
+      <point x="414" y="881"/>
+      <point x="379" y="827" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="343" y="772"/>
+      <point x="309" y="629"/>
+      <point x="309" y="550" type="qcurve" smooth="yes"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Regular.ufo/glyphs/dotbelow.glif
+++ b/sources/RobotoMono-Regular.ufo/glyphs/dotbelow.glif
@@ -1,6 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="dotbelow" format="2">
-  <advance width="1106"/>
   <unicode hex="0323"/>
   <outline>
     <contour>

--- a/sources/RobotoMono-Regular.ufo/glyphs/exclamdbl.glif
+++ b/sources/RobotoMono-Regular.ufo/glyphs/exclamdbl.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="exclamdbl" format="2">
-  <advance width="2458"/>
+  <advance width="1229"/>
   <unicode hex="203C"/>
   <outline>
-    <component base="exclam"/>
-    <component base="exclam" xOffset="1229"/>
+    <component base="exclam" xOffset="-382"/>
+    <component base="exclam" xOffset="410"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Regular.ufo/glyphs/f.glif
+++ b/sources/RobotoMono-Regular.ufo/glyphs/f.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f" format="2">
-  <advance width="1230"/>
+  <advance width="1229"/>
   <unicode hex="0066"/>
   <outline>
     <contour>

--- a/sources/RobotoMono-Regular.ufo/glyphs/gravecomb.glif
+++ b/sources/RobotoMono-Regular.ufo/glyphs/gravecomb.glif
@@ -1,6 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="gravecomb" format="2">
-  <advance width="1106"/>
   <unicode hex="0300"/>
   <outline>
     <contour>

--- a/sources/RobotoMono-Regular.ufo/glyphs/hbar.glif
+++ b/sources/RobotoMono-Regular.ufo/glyphs/hbar.glif
@@ -1,49 +1,49 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="hbar" format="2">
-  <advance width="1259"/>
+  <advance width="1229"/>
   <unicode hex="0127"/>
   <outline>
     <contour>
-      <point x="663" y="1234" type="line"/>
-      <point x="389" y="1234" type="line"/>
-      <point x="389" y="921" type="line"/>
-      <point x="416" y="961"/>
-      <point x="483" y="1025"/>
-      <point x="522" y="1048" type="qcurve" smooth="yes"/>
-      <point x="566" y="1074"/>
-      <point x="667" y="1101"/>
-      <point x="723" y="1102" type="qcurve" smooth="yes"/>
-      <point x="808" y="1102"/>
-      <point x="947" y="1053"/>
-      <point x="996" y="1001" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="1045" y="949"/>
-      <point x="1098" y="790"/>
-      <point x="1098" y="681" type="qcurve" smooth="yes"/>
-      <point x="1098" y="0" type="line"/>
-      <point x="913" y="0" type="line"/>
-      <point x="913" y="683" type="line" smooth="yes"/>
-      <point x="913" y="749"/>
-      <point x="881" y="848"/>
-      <point x="851" y="880" type="qcurve" smooth="yes"/>
-      <point x="820" y="913"/>
-      <point x="727" y="946"/>
-      <point x="668" y="945" type="qcurve" smooth="yes"/>
-      <point x="618" y="945"/>
-      <point x="527" y="917"/>
-      <point x="489" y="891" type="qcurve" smooth="yes"/>
-      <point x="459" y="871"/>
-      <point x="409" y="818"/>
-      <point x="389" y="786" type="qcurve"/>
-      <point x="389" y="0" type="line"/>
-      <point x="204" y="0" type="line"/>
-      <point x="204" y="1234" type="line"/>
-      <point x="26" y="1234" type="line"/>
-      <point x="26" y="1385" type="line"/>
-      <point x="204" y="1385" type="line"/>
-      <point x="204" y="1536" type="line"/>
-      <point x="389" y="1536" type="line"/>
-      <point x="389" y="1385" type="line"/>
-      <point x="663" y="1385" type="line"/>
+      <point x="648" y="1234" type="line"/>
+      <point x="374" y="1234" type="line"/>
+      <point x="374" y="921" type="line"/>
+      <point x="401" y="961"/>
+      <point x="468" y="1025"/>
+      <point x="507" y="1048" type="qcurve" smooth="yes"/>
+      <point x="551" y="1074"/>
+      <point x="652" y="1101"/>
+      <point x="708" y="1102" type="qcurve" smooth="yes"/>
+      <point x="793" y="1102"/>
+      <point x="932" y="1053"/>
+      <point x="981" y="1001" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="1030" y="949"/>
+      <point x="1083" y="790"/>
+      <point x="1083" y="681" type="qcurve" smooth="yes"/>
+      <point x="1083" y="0" type="line"/>
+      <point x="898" y="0" type="line"/>
+      <point x="898" y="683" type="line" smooth="yes"/>
+      <point x="898" y="749"/>
+      <point x="866" y="848"/>
+      <point x="836" y="880" type="qcurve" smooth="yes"/>
+      <point x="805" y="913"/>
+      <point x="712" y="946"/>
+      <point x="653" y="945" type="qcurve" smooth="yes"/>
+      <point x="603" y="945"/>
+      <point x="512" y="917"/>
+      <point x="474" y="891" type="qcurve" smooth="yes"/>
+      <point x="444" y="871"/>
+      <point x="394" y="818"/>
+      <point x="374" y="786" type="qcurve"/>
+      <point x="374" y="0" type="line"/>
+      <point x="189" y="0" type="line"/>
+      <point x="189" y="1234" type="line"/>
+      <point x="11" y="1234" type="line"/>
+      <point x="11" y="1385" type="line"/>
+      <point x="189" y="1385" type="line"/>
+      <point x="189" y="1536" type="line"/>
+      <point x="374" y="1536" type="line"/>
+      <point x="374" y="1385" type="line"/>
+      <point x="648" y="1385" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Regular.ufo/glyphs/hook.glif
+++ b/sources/RobotoMono-Regular.ufo/glyphs/hook.glif
@@ -1,6 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="hook" format="2">
-  <advance width="1106"/>
   <unicode hex="0309"/>
   <outline>
     <contour>

--- a/sources/RobotoMono-Regular.ufo/glyphs/hyphen.glif
+++ b/sources/RobotoMono-Regular.ufo/glyphs/hyphen.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="hyphen" format="2">
-  <advance width="1230"/>
+  <advance width="1229"/>
   <unicode hex="002D"/>
   <outline>
     <contour>

--- a/sources/RobotoMono-Regular.ufo/glyphs/lcaron.glif
+++ b/sources/RobotoMono-Regular.ufo/glyphs/lcaron.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="lcaron" format="2">
-  <advance width="1379"/>
+  <advance width="1229"/>
   <unicode hex="013E"/>
   <outline>
-    <component base="l"/>
-    <component base="quoteright" xOffset="513" yOffset="-18"/>
+    <component base="l" xOffset="-50"/>
+    <component base="quoteright" xOffset="463" yOffset="-18"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Regular.ufo/glyphs/ldot.glif
+++ b/sources/RobotoMono-Regular.ufo/glyphs/ldot.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ldot" format="2">
-  <advance width="1449"/>
+  <advance width="1229"/>
   <unicode hex="0140"/>
   <outline>
-    <component base="l"/>
-    <component base="dotaccent" xOffset="384" yOffset="-537"/>
+    <component base="l" xOffset="-70" yOffset="1"/>
+    <component base="dotaccent" xOffset="314" yOffset="-537"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Regular.ufo/glyphs/tcaron.glif
+++ b/sources/RobotoMono-Regular.ufo/glyphs/tcaron.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="tcaron" format="2">
-  <advance width="1269"/>
+  <advance width="1229"/>
   <unicode hex="0165"/>
   <outline>
-    <component base="t"/>
-    <component base="quoteright" xOffset="412" yOffset="157"/>
+    <component base="t" xOffset="-15"/>
+    <component base="quoteright" xOffset="417" yOffset="157"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Regular.ufo/glyphs/tildecomb.glif
+++ b/sources/RobotoMono-Regular.ufo/glyphs/tildecomb.glif
@@ -1,6 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="tildecomb" format="2">
-  <advance width="1106"/>
   <unicode hex="0303"/>
   <outline>
     <component base="tilde" xOffset="-1026"/>

--- a/sources/RobotoMono-Regular.ufo/glyphs/uni00A_D_.glif
+++ b/sources/RobotoMono-Regular.ufo/glyphs/uni00A_D_.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni00AD" format="2">
-  <advance width="1230"/>
+  <advance width="1229"/>
   <unicode hex="00AD"/>
   <outline>
     <component base="hyphen"/>

--- a/sources/RobotoMono-Regular.ufo/glyphs/uni030F_.glif
+++ b/sources/RobotoMono-Regular.ufo/glyphs/uni030F_.glif
@@ -1,6 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni030F" format="2">
-  <advance width="1106"/>
   <unicode hex="030F"/>
   <outline>
     <contour>

--- a/sources/RobotoMono-Regular.ufo/glyphs/uni0483.glif
+++ b/sources/RobotoMono-Regular.ufo/glyphs/uni0483.glif
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni0483" format="2">
+  <advance width="1229"/>
   <unicode hex="0483"/>
   <outline>
     <contour>

--- a/sources/RobotoMono-Regular.ufo/glyphs/uni0484.glif
+++ b/sources/RobotoMono-Regular.ufo/glyphs/uni0484.glif
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni0484" format="2">
+  <advance width="1229"/>
   <unicode hex="0484"/>
   <outline>
     <contour>

--- a/sources/RobotoMono-Regular.ufo/glyphs/uni0485.glif
+++ b/sources/RobotoMono-Regular.ufo/glyphs/uni0485.glif
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni0485" format="2">
+  <advance width="1229"/>
   <unicode hex="0485"/>
   <outline>
     <contour>

--- a/sources/RobotoMono-Regular.ufo/glyphs/uni0486.glif
+++ b/sources/RobotoMono-Regular.ufo/glyphs/uni0486.glif
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni0486" format="2">
+  <advance width="1229"/>
   <unicode hex="0486"/>
   <outline>
     <contour>

--- a/sources/RobotoMono-Regular.ufo/glyphs/uni0488.glif
+++ b/sources/RobotoMono-Regular.ufo/glyphs/uni0488.glif
@@ -1,182 +1,183 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni0488" format="2">
+  <advance width="1229"/>
   <unicode hex="0488"/>
   <outline>
     <contour>
-      <point x="468" y="1267" type="line"/>
-      <point x="468" y="1308"/>
-      <point x="497" y="1377"/>
-      <point x="524.5" y="1402.0" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="552" y="1427"/>
-      <point x="630" y="1455"/>
-      <point x="678" y="1455" type="qcurve" smooth="yes"/>
-      <point x="726" y="1455"/>
-      <point x="804" y="1427"/>
-      <point x="831.5" y="1402.0" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="859" y="1377"/>
-      <point x="889" y="1308"/>
-      <point x="889" y="1267" type="qcurve"/>
-      <point x="777" y="1267" type="line"/>
-      <point x="777.0" y="1307.0"/>
-      <point x="731.9999999999999" y="1368.0"/>
-      <point x="678" y="1368" type="qcurve" smooth="yes"/>
-      <point x="623.0376548823334" y="1368.0"/>
-      <point x="581.0" y="1306.311684972332"/>
-      <point x="581" y="1267" type="qcurve"/>
+      <point x="408" y="1267" type="line"/>
+      <point x="408" y="1308"/>
+      <point x="437" y="1377"/>
+      <point x="465" y="1402" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="492" y="1427"/>
+      <point x="570" y="1455"/>
+      <point x="618" y="1455" type="qcurve" smooth="yes"/>
+      <point x="666" y="1455"/>
+      <point x="744" y="1427"/>
+      <point x="772" y="1402" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="799" y="1377"/>
+      <point x="829" y="1308"/>
+      <point x="829" y="1267" type="qcurve"/>
+      <point x="717" y="1267" type="line"/>
+      <point x="717" y="1307"/>
+      <point x="672" y="1368"/>
+      <point x="618" y="1368" type="qcurve" smooth="yes"/>
+      <point x="563" y="1368"/>
+      <point x="521" y="1306"/>
+      <point x="521" y="1267" type="qcurve"/>
     </contour>
     <contour>
-      <point x="1059" y="990" type="line"/>
-      <point x="1059" y="1031"/>
-      <point x="1089" y="1100"/>
-      <point x="1116.0" y="1125.0" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="1143" y="1150"/>
-      <point x="1221" y="1178"/>
-      <point x="1269" y="1178" type="qcurve" smooth="yes"/>
-      <point x="1317" y="1178"/>
-      <point x="1395" y="1150"/>
-      <point x="1423.0" y="1125.0" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="1451" y="1100"/>
-      <point x="1481" y="1031"/>
-      <point x="1481" y="990" type="qcurve"/>
-      <point x="1368" y="990" type="line"/>
-      <point x="1368.0" y="1030.0"/>
-      <point x="1323.0" y="1091.0"/>
-      <point x="1269" y="1091" type="qcurve" smooth="yes"/>
-      <point x="1216.073297294099" y="1091.0"/>
-      <point x="1173.0" y="1029.311684972332"/>
-      <point x="1173" y="990" type="qcurve"/>
+      <point x="999" y="990" type="line"/>
+      <point x="999" y="1031"/>
+      <point x="1029" y="1100"/>
+      <point x="1056" y="1125" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="1083" y="1150"/>
+      <point x="1161" y="1178"/>
+      <point x="1209" y="1178" type="qcurve" smooth="yes"/>
+      <point x="1257" y="1178"/>
+      <point x="1335" y="1150"/>
+      <point x="1363" y="1125" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="1391" y="1100"/>
+      <point x="1421" y="1031"/>
+      <point x="1421" y="990" type="qcurve"/>
+      <point x="1308" y="990" type="line"/>
+      <point x="1308" y="1030"/>
+      <point x="1263" y="1091"/>
+      <point x="1209" y="1091" type="qcurve" smooth="yes"/>
+      <point x="1156" y="1091"/>
+      <point x="1113" y="1029"/>
+      <point x="1113" y="990" type="qcurve"/>
     </contour>
     <contour>
-      <point x="1246" y="487" type="line"/>
-      <point x="1246" y="528"/>
-      <point x="1276" y="597"/>
-      <point x="1303.0" y="622.0" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="1330" y="647"/>
-      <point x="1408" y="675"/>
-      <point x="1456" y="675" type="qcurve" smooth="yes"/>
-      <point x="1504" y="675"/>
-      <point x="1582" y="647"/>
-      <point x="1609.5" y="622.0" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="1637" y="597"/>
-      <point x="1667" y="528"/>
-      <point x="1667" y="487" type="qcurve"/>
-      <point x="1555" y="487" type="line"/>
-      <point x="1555.0" y="526.9999999999999"/>
-      <point x="1510.0" y="588.0"/>
-      <point x="1456" y="588" type="qcurve" smooth="yes"/>
-      <point x="1403.073297294099" y="588.0"/>
-      <point x="1359.0" y="526.3116849723318"/>
-      <point x="1359" y="487" type="qcurve"/>
+      <point x="1186" y="487" type="line"/>
+      <point x="1186" y="528"/>
+      <point x="1216" y="597"/>
+      <point x="1243" y="622" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="1270" y="647"/>
+      <point x="1348" y="675"/>
+      <point x="1396" y="675" type="qcurve" smooth="yes"/>
+      <point x="1444" y="675"/>
+      <point x="1522" y="647"/>
+      <point x="1550" y="622" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="1577" y="597"/>
+      <point x="1607" y="528"/>
+      <point x="1607" y="487" type="qcurve"/>
+      <point x="1495" y="487" type="line"/>
+      <point x="1495" y="527"/>
+      <point x="1450" y="588"/>
+      <point x="1396" y="588" type="qcurve" smooth="yes"/>
+      <point x="1343" y="588"/>
+      <point x="1299" y="526"/>
+      <point x="1299" y="487" type="qcurve"/>
     </contour>
     <contour>
-      <point x="1049" y="-32" type="line"/>
-      <point x="1049" y="9"/>
-      <point x="1079" y="78"/>
-      <point x="1106.0" y="103.0" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="1133" y="128"/>
-      <point x="1211" y="156"/>
-      <point x="1259" y="156" type="qcurve" smooth="yes"/>
-      <point x="1307" y="156"/>
-      <point x="1385" y="128"/>
-      <point x="1412.5" y="103.0" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="1440" y="78"/>
-      <point x="1470" y="9"/>
-      <point x="1470" y="-32" type="qcurve"/>
-      <point x="1358" y="-32" type="line"/>
-      <point x="1358.0" y="8.000000000000007"/>
-      <point x="1313.0" y="69.0"/>
-      <point x="1259" y="69" type="qcurve" smooth="yes"/>
-      <point x="1206.073297294099" y="69.0"/>
-      <point x="1162.0" y="7.3116849723319035"/>
-      <point x="1162" y="-32" type="qcurve"/>
+      <point x="989" y="-32" type="line"/>
+      <point x="989" y="9"/>
+      <point x="1019" y="78"/>
+      <point x="1046" y="103" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="1073" y="128"/>
+      <point x="1151" y="156"/>
+      <point x="1199" y="156" type="qcurve" smooth="yes"/>
+      <point x="1247" y="156"/>
+      <point x="1325" y="128"/>
+      <point x="1353" y="103" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="1380" y="78"/>
+      <point x="1410" y="9"/>
+      <point x="1410" y="-32" type="qcurve"/>
+      <point x="1298" y="-32" type="line"/>
+      <point x="1298" y="8"/>
+      <point x="1253" y="69"/>
+      <point x="1199" y="69" type="qcurve" smooth="yes"/>
+      <point x="1146" y="69"/>
+      <point x="1102" y="7"/>
+      <point x="1102" y="-32" type="qcurve"/>
     </contour>
     <contour>
-      <point x="473" y="-316" type="line"/>
-      <point x="473" y="-274"/>
-      <point x="502" y="-205"/>
-      <point x="529.5" y="-180.5" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="557" y="-156"/>
-      <point x="635" y="-128"/>
-      <point x="683" y="-128" type="qcurve" smooth="yes"/>
-      <point x="731" y="-128"/>
-      <point x="809" y="-156"/>
-      <point x="836.5" y="-180.5" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="864" y="-205"/>
-      <point x="894" y="-274"/>
-      <point x="894" y="-316" type="qcurve"/>
-      <point x="782" y="-316" type="line"/>
-      <point x="782.0" y="-276.0"/>
-      <point x="736.9999999999999" y="-215.0"/>
-      <point x="683" y="-215" type="qcurve" smooth="yes"/>
-      <point x="630.0732972940988" y="-215.0"/>
-      <point x="586.0" y="-276.6883150276682"/>
-      <point x="586" y="-316" type="qcurve"/>
+      <point x="413" y="-316" type="line"/>
+      <point x="413" y="-274"/>
+      <point x="442" y="-205"/>
+      <point x="470" y="-180" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="497" y="-156"/>
+      <point x="575" y="-128"/>
+      <point x="623" y="-128" type="qcurve" smooth="yes"/>
+      <point x="671" y="-128"/>
+      <point x="749" y="-156"/>
+      <point x="777" y="-180" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="804" y="-205"/>
+      <point x="834" y="-274"/>
+      <point x="834" y="-316" type="qcurve"/>
+      <point x="722" y="-316" type="line"/>
+      <point x="722" y="-276"/>
+      <point x="677" y="-215"/>
+      <point x="623" y="-215" type="qcurve" smooth="yes"/>
+      <point x="570" y="-215"/>
+      <point x="526" y="-277"/>
+      <point x="526" y="-316" type="qcurve"/>
     </contour>
     <contour>
-      <point x="-105" y="990" type="line"/>
-      <point x="-105" y="1031"/>
-      <point x="-75" y="1100"/>
-      <point x="-47.5" y="1125.0" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="-20" y="1150"/>
-      <point x="58" y="1178"/>
-      <point x="106" y="1178" type="qcurve" smooth="yes"/>
-      <point x="154" y="1178"/>
-      <point x="232" y="1150"/>
-      <point x="259.5" y="1125.0" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="287" y="1100"/>
-      <point x="317" y="1031"/>
-      <point x="317" y="990" type="qcurve"/>
-      <point x="205" y="990" type="line"/>
-      <point x="205.0" y="1030.0"/>
-      <point x="160.0" y="1091.0"/>
-      <point x="106" y="1091" type="qcurve" smooth="yes"/>
-      <point x="51.03765488233335" y="1091.0"/>
-      <point x="9.0" y="1029.311684972332"/>
-      <point x="9" y="990" type="qcurve"/>
+      <point x="-165" y="990" type="line"/>
+      <point x="-165" y="1031"/>
+      <point x="-135" y="1100"/>
+      <point x="-107" y="1125" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="-80" y="1150"/>
+      <point x="-2" y="1178"/>
+      <point x="46" y="1178" type="qcurve" smooth="yes"/>
+      <point x="94" y="1178"/>
+      <point x="172" y="1150"/>
+      <point x="200" y="1125" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="227" y="1100"/>
+      <point x="257" y="1031"/>
+      <point x="257" y="990" type="qcurve"/>
+      <point x="145" y="990" type="line"/>
+      <point x="145" y="1030"/>
+      <point x="100" y="1091"/>
+      <point x="46" y="1091" type="qcurve" smooth="yes"/>
+      <point x="-9" y="1091"/>
+      <point x="-51" y="1029"/>
+      <point x="-51" y="990" type="qcurve"/>
     </contour>
     <contour>
-      <point x="-281" y="487" type="line"/>
-      <point x="-281" y="528"/>
-      <point x="-251" y="597"/>
-      <point x="-223.5" y="622.0" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="-196" y="647"/>
-      <point x="-119" y="675"/>
-      <point x="-71" y="675" type="qcurve" smooth="yes"/>
-      <point x="-23" y="675"/>
-      <point x="55" y="647"/>
-      <point x="82.5" y="622.0" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="110" y="597"/>
-      <point x="140" y="528"/>
-      <point x="140" y="487" type="qcurve"/>
-      <point x="28" y="487" type="line"/>
-      <point x="28.0" y="526.9999999999999"/>
-      <point x="-17.000000000000007" y="588.0"/>
-      <point x="-71" y="588" type="qcurve" smooth="yes"/>
-      <point x="-123.0" y="588.0"/>
-      <point x="-168.0" y="526.9999999999999"/>
-      <point x="-168" y="487" type="qcurve"/>
+      <point x="-341" y="487" type="line"/>
+      <point x="-341" y="528"/>
+      <point x="-311" y="597"/>
+      <point x="-283" y="622" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="-256" y="647"/>
+      <point x="-179" y="675"/>
+      <point x="-131" y="675" type="qcurve" smooth="yes"/>
+      <point x="-83" y="675"/>
+      <point x="-5" y="647"/>
+      <point x="23" y="622" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="50" y="597"/>
+      <point x="80" y="528"/>
+      <point x="80" y="487" type="qcurve"/>
+      <point x="-32" y="487" type="line"/>
+      <point x="-32" y="527"/>
+      <point x="-77" y="588"/>
+      <point x="-131" y="588" type="qcurve" smooth="yes"/>
+      <point x="-183" y="588"/>
+      <point x="-228" y="527"/>
+      <point x="-228" y="487" type="qcurve"/>
     </contour>
     <contour>
-      <point x="-115" y="-32" type="line"/>
-      <point x="-115" y="9"/>
-      <point x="-85" y="78"/>
-      <point x="-57.5" y="103.0" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="-30" y="128"/>
-      <point x="47" y="156"/>
-      <point x="95" y="156" type="qcurve" smooth="yes"/>
-      <point x="143" y="156"/>
-      <point x="221" y="128"/>
-      <point x="249.0" y="103.0" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="277" y="78"/>
-      <point x="307" y="9"/>
-      <point x="307" y="-32" type="qcurve"/>
-      <point x="194" y="-32" type="line"/>
-      <point x="194.0" y="8.0"/>
-      <point x="149.0" y="69.0"/>
-      <point x="95" y="69" type="qcurve" smooth="yes"/>
-      <point x="43.00000000000001" y="69.0"/>
-      <point x="-1.0" y="8.000000000000007"/>
-      <point x="-1" y="-32" type="qcurve"/>
+      <point x="-175" y="-32" type="line"/>
+      <point x="-175" y="9"/>
+      <point x="-145" y="78"/>
+      <point x="-117" y="103" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="-90" y="128"/>
+      <point x="-13" y="156"/>
+      <point x="35" y="156" type="qcurve" smooth="yes"/>
+      <point x="83" y="156"/>
+      <point x="161" y="128"/>
+      <point x="189" y="103" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="217" y="78"/>
+      <point x="247" y="9"/>
+      <point x="247" y="-32" type="qcurve"/>
+      <point x="134" y="-32" type="line"/>
+      <point x="134" y="8"/>
+      <point x="89" y="69"/>
+      <point x="35" y="69" type="qcurve" smooth="yes"/>
+      <point x="-17" y="69"/>
+      <point x="-61" y="8"/>
+      <point x="-61" y="-32" type="qcurve"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Regular.ufo/glyphs/uni0489.glif
+++ b/sources/RobotoMono-Regular.ufo/glyphs/uni0489.glif
@@ -1,62 +1,63 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni0489" format="2">
+  <advance width="1229"/>
   <unicode hex="0489"/>
   <outline>
     <contour>
-      <point x="1105" y="-60" type="line"/>
-      <point x="1116" y="-74" type="line"/>
-      <point x="994" y="-413" type="line"/>
-      <point x="898" y="-413" type="line"/>
-      <point x="968" y="-60" type="line"/>
+      <point x="695" y="-60" type="line"/>
+      <point x="706" y="-74" type="line"/>
+      <point x="584" y="-413" type="line"/>
+      <point x="488" y="-413" type="line"/>
+      <point x="558" y="-60" type="line"/>
     </contour>
     <contour>
-      <point x="910" y="1126" type="line"/>
-      <point x="898" y="1140" type="line"/>
-      <point x="1020" y="1478" type="line"/>
-      <point x="1116" y="1478" type="line"/>
-      <point x="1046" y="1126" type="line"/>
+      <point x="500" y="1126" type="line"/>
+      <point x="488" y="1140" type="line"/>
+      <point x="610" y="1478" type="line"/>
+      <point x="706" y="1478" type="line"/>
+      <point x="636" y="1126" type="line"/>
     </contour>
     <contour>
-      <point x="1588" y="631" type="line"/>
-      <point x="1601" y="643" type="line"/>
-      <point x="1934" y="519" type="line"/>
-      <point x="1934" y="421" type="line"/>
-      <point x="1588" y="492" type="line"/>
+      <point x="1178" y="631" type="line"/>
+      <point x="1191" y="643" type="line"/>
+      <point x="1524" y="519" type="line"/>
+      <point x="1524" y="421" type="line"/>
+      <point x="1178" y="492" type="line"/>
     </contour>
     <contour>
-      <point x="424" y="433" type="line"/>
-      <point x="411" y="421" type="line"/>
-      <point x="78" y="545" type="line"/>
-      <point x="78" y="643" type="line"/>
-      <point x="424" y="572" type="line"/>
+      <point x="14" y="433" type="line"/>
+      <point x="1" y="421" type="line"/>
+      <point x="-332" y="545" type="line"/>
+      <point x="-332" y="643" type="line"/>
+      <point x="14" y="572" type="line"/>
     </contour>
     <contour>
-      <point x="1348" y="1002" type="line"/>
-      <point x="1350" y="1018" type="line"/>
-      <point x="1671" y="1171" type="line"/>
-      <point x="1739" y="1103" type="line"/>
-      <point x="1445" y="903" type="line"/>
+      <point x="938" y="1002" type="line"/>
+      <point x="940" y="1018" type="line"/>
+      <point x="1261" y="1171" type="line"/>
+      <point x="1329" y="1103" type="line"/>
+      <point x="1035" y="903" type="line"/>
     </contour>
     <contour>
-      <point x="664" y="21" type="line"/>
-      <point x="662" y="4" type="line"/>
-      <point x="342" y="-149" type="line"/>
-      <point x="273" y="-80" type="line"/>
-      <point x="567" y="120" type="line"/>
+      <point x="254" y="21" type="line"/>
+      <point x="252" y="4" type="line"/>
+      <point x="-68" y="-149" type="line"/>
+      <point x="-137" y="-80" type="line"/>
+      <point x="157" y="120" type="line"/>
     </contour>
     <contour>
-      <point x="524" y="860" type="line"/>
-      <point x="507" y="862" type="line"/>
-      <point x="359" y="1188" type="line"/>
-      <point x="424" y="1257" type="line"/>
-      <point x="622" y="958" type="line"/>
+      <point x="114" y="860" type="line"/>
+      <point x="97" y="862" type="line"/>
+      <point x="-51" y="1188" type="line"/>
+      <point x="14" y="1257" type="line"/>
+      <point x="212" y="958" type="line"/>
     </contour>
     <contour>
-      <point x="1486" y="161" type="line"/>
-      <point x="1503" y="159" type="line"/>
-      <point x="1652" y="-166" type="line"/>
-      <point x="1586" y="-237" type="line"/>
-      <point x="1389" y="62" type="line"/>
+      <point x="1076" y="161" type="line"/>
+      <point x="1093" y="159" type="line"/>
+      <point x="1242" y="-166" type="line"/>
+      <point x="1176" y="-237" type="line"/>
+      <point x="979" y="62" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Regular.ufo/glyphs/uni049E_.glif
+++ b/sources/RobotoMono-Regular.ufo/glyphs/uni049E_.glif
@@ -1,30 +1,30 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni049E" format="2">
-  <advance width="1249"/>
+  <advance width="1229"/>
   <unicode hex="049E"/>
   <outline>
     <contour>
-      <point x="545" y="659" type="line"/>
-      <point x="374" y="659" type="line"/>
-      <point x="374" y="0" type="line"/>
-      <point x="189" y="0" type="line"/>
-      <point x="189" y="1129" type="line"/>
-      <point x="9" y="1129" type="line"/>
-      <point x="9" y="1280" type="line"/>
-      <point x="189" y="1280" type="line"/>
-      <point x="189" y="1456" type="line"/>
-      <point x="374" y="1456" type="line"/>
-      <point x="374" y="1280" type="line"/>
-      <point x="646" y="1280" type="line"/>
-      <point x="646" y="1129" type="line"/>
-      <point x="374" y="1129" type="line"/>
-      <point x="374" y="810" type="line"/>
-      <point x="530" y="810" type="line"/>
-      <point x="973" y="1456" type="line"/>
-      <point x="1185" y="1456" type="line"/>
-      <point x="690" y="751" type="line"/>
-      <point x="1226" y="0" type="line"/>
-      <point x="999" y="0" type="line"/>
+      <point x="535" y="659" type="line"/>
+      <point x="364" y="659" type="line"/>
+      <point x="364" y="0" type="line"/>
+      <point x="179" y="0" type="line"/>
+      <point x="179" y="1129" type="line"/>
+      <point x="-1" y="1129" type="line"/>
+      <point x="-1" y="1280" type="line"/>
+      <point x="179" y="1280" type="line"/>
+      <point x="179" y="1456" type="line"/>
+      <point x="364" y="1456" type="line"/>
+      <point x="364" y="1280" type="line"/>
+      <point x="636" y="1280" type="line"/>
+      <point x="636" y="1129" type="line"/>
+      <point x="364" y="1129" type="line"/>
+      <point x="364" y="810" type="line"/>
+      <point x="520" y="810" type="line"/>
+      <point x="963" y="1456" type="line"/>
+      <point x="1175" y="1456" type="line"/>
+      <point x="680" y="751" type="line"/>
+      <point x="1216" y="0" type="line"/>
+      <point x="989" y="0" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Regular.ufo/glyphs/uni049F_.glif
+++ b/sources/RobotoMono-Regular.ufo/glyphs/uni049F_.glif
@@ -1,30 +1,30 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni049F" format="2">
-  <advance width="1249"/>
+  <advance width="1229"/>
   <unicode hex="049F"/>
   <outline>
     <contour>
-      <point x="196" y="0" type="line"/>
-      <point x="196" y="1217" type="line"/>
-      <point x="-13" y="1217" type="line"/>
-      <point x="-13" y="1368" type="line"/>
-      <point x="196" y="1368" type="line"/>
-      <point x="196" y="1536" type="line"/>
-      <point x="382" y="1536" type="line"/>
-      <point x="382" y="1368" type="line"/>
-      <point x="624" y="1368" type="line"/>
-      <point x="624" y="1217" type="line"/>
-      <point x="382" y="1217" type="line"/>
-      <point x="382" y="596" type="line"/>
-      <point x="503" y="726" type="line"/>
-      <point x="858" y="1082" type="line"/>
-      <point x="1083" y="1082" type="line"/>
-      <point x="645" y="631" type="line"/>
-      <point x="1150" y="0" type="line"/>
-      <point x="915" y="0" type="line"/>
-      <point x="518" y="505" type="line"/>
-      <point x="382" y="374" type="line"/>
-      <point x="382" y="0" type="line"/>
+      <point x="186" y="0" type="line"/>
+      <point x="186" y="1217" type="line"/>
+      <point x="-23" y="1217" type="line"/>
+      <point x="-23" y="1368" type="line"/>
+      <point x="186" y="1368" type="line"/>
+      <point x="186" y="1536" type="line"/>
+      <point x="372" y="1536" type="line"/>
+      <point x="372" y="1368" type="line"/>
+      <point x="614" y="1368" type="line"/>
+      <point x="614" y="1217" type="line"/>
+      <point x="372" y="1217" type="line"/>
+      <point x="372" y="596" type="line"/>
+      <point x="493" y="726" type="line"/>
+      <point x="848" y="1082" type="line"/>
+      <point x="1073" y="1082" type="line"/>
+      <point x="635" y="631" type="line"/>
+      <point x="1140" y="0" type="line"/>
+      <point x="905" y="0" type="line"/>
+      <point x="508" y="505" type="line"/>
+      <point x="372" y="374" type="line"/>
+      <point x="372" y="0" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Regular.ufo/glyphs/uni20A_B_.glif
+++ b/sources/RobotoMono-Regular.ufo/glyphs/uni20A_B_.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni20AB" format="2">
-  <advance width="1259"/>
+  <advance width="1229"/>
   <unicode hex="20AB"/>
   <outline>
-    <component base="d"/>
+    <component base="d" xOffset="-15"/>
     <component base="crossbar" xOffset="303" yOffset="583"/>
-    <component base="underscore" xOffset="48" yOffset="-124"/>
+    <component base="underscore" xOffset="33" yOffset="-124"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Regular.ufo/lib.plist
+++ b/sources/RobotoMono-Regular.ufo/lib.plist
@@ -2,6 +2,17 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
   <dict>
+    <key>com.defcon.sortDescriptor</key>
+    <array>
+      <dict>
+        <key>allowPseudoUnicode</key>
+        <integer>0</integer>
+        <key>ascending</key>
+        <string>Amstelvar DB Best</string>
+        <key>type</key>
+        <string>characterSet</string>
+      </dict>
+    </array>
     <key>com.typemytype.robofont.binarySource</key>
     <string>/Users/pichotta/Downloads/Roboto_Mono/RobotoMono-Regular.ttf</string>
     <key>com.typemytype.robofont.fontIdentifier</key>
@@ -10,41 +21,8 @@
     <string>qcurve</string>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
       <string>NULL</string>
-      <string>nonmarkingreturn</string>
       <string>space</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
       <string>B</string>
       <string>C</string>
@@ -71,12 +49,6 @@
       <string>X</string>
       <string>Y</string>
       <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
       <string>a</string>
       <string>b</string>
       <string>c</string>
@@ -103,84 +75,329 @@
       <string>x</string>
       <string>y</string>
       <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemotleft</string>
-      <string>logicalnot</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
+      <string>onesuperior</string>
       <string>twosuperior</string>
       <string>threesuperior</string>
-      <string>acute</string>
-      <string>mu</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
+      <string>ordfeminine</string>
       <string>ordmasculine</string>
-      <string>guillemotright</string>
-      <string>onequarter</string>
       <string>onehalf</string>
+      <string>onequarter</string>
       <string>threequarters</string>
-      <string>questiondown</string>
       <string>AE</string>
-      <string>multiply</string>
-      <string>Oslash</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
       <string>ae</string>
+      <string>OE</string>
+      <string>oe</string>
       <string>eth</string>
-      <string>divide</string>
-      <string>oslash</string>
+      <string>Thorn</string>
       <string>thorn</string>
+      <string>kgreenlandic</string>
+      <string>germandbls</string>
+      <string>schwa</string>
+      <string>dollar</string>
+      <string>cent</string>
+      <string>sterling</string>
+      <string>yen</string>
+      <string>florin</string>
+      <string>franc</string>
+      <string>lira</string>
+      <string>peseta</string>
+      <string>currency</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>comma</string>
+      <string>period</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>ellipsis</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>underscore</string>
+      <string>hyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>quotesingle</string>
+      <string>quotedbl</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quotedblbase</string>
+      <string>minute</string>
+      <string>second</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>plusminus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>approxequal</string>
+      <string>less</string>
+      <string>greater</string>
+      <string>lessequal</string>
+      <string>greaterequal</string>
+      <string>logicalnot</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>fraction</string>
+      <string>percent</string>
+      <string>perthousand</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>dagger</string>
+      <string>daggerdbl</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>ampersand</string>
+      <string>at</string>
+      <string>section</string>
+      <string>paragraph</string>
+      <string>asciicircum</string>
+      <string>asciitilde</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Acircumflex</string>
+      <string>Adieresis</string>
+      <string>Agrave</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Aringacute</string>
+      <string>Atilde</string>
+      <string>AEacute</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Ccircumflex</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Eacute</string>
+      <string>Ebreve</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Egrave</string>
+      <string>Emacron</string>
+      <string>Eng</string>
+      <string>Eogonek</string>
+      <string>Eth</string>
+      <string>Gbreve</string>
+      <string>Gcircumflex</string>
+      <string>Gcommaaccent</string>
       <string>Hbar</string>
+      <string>Hcircumflex</string>
+      <string>Iacute</string>
+      <string>Ibreve</string>
+      <string>Icircumflex</string>
+      <string>Idieresis</string>
+      <string>Idotaccent</string>
+      <string>Igrave</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>Jcircumflex</string>
+      <string>Kcommaaccent</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ntilde</string>
+      <string>Oacute</string>
+      <string>Obreve</string>
+      <string>Ocircumflex</string>
+      <string>Odieresis</string>
+      <string>Ograve</string>
+      <string>Ohorn</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
+      <string>Oslash</string>
+      <string>Oslashacute</string>
+      <string>Otilde</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scircumflex</string>
+      <string>Tbar</string>
+      <string>Tcaron</string>
+      <string>Uacute</string>
+      <string>Ubreve</string>
+      <string>Ucircumflex</string>
+      <string>Udieresis</string>
+      <string>Ugrave</string>
+      <string>Uhorn</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>Yacute</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ygrave</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>aacute</string>
+      <string>abreve</string>
+      <string>acircumflex</string>
+      <string>adieresis</string>
+      <string>agrave</string>
+      <string>amacron</string>
+      <string>aogonek</string>
+      <string>aring</string>
+      <string>aringacute</string>
+      <string>atilde</string>
+      <string>aeacute</string>
+      <string>cacute</string>
+      <string>ccaron</string>
+      <string>ccedilla</string>
+      <string>ccircumflex</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>eacute</string>
+      <string>ebreve</string>
+      <string>ecaron</string>
+      <string>ecircumflex</string>
+      <string>edieresis</string>
+      <string>edotaccent</string>
+      <string>egrave</string>
+      <string>emacron</string>
+      <string>eng</string>
+      <string>eogonek</string>
+      <string>gbreve</string>
+      <string>gcircumflex</string>
+      <string>gcommaaccent</string>
+      <string>hbar</string>
+      <string>hcircumflex</string>
+      <string>iacute</string>
+      <string>ibreve</string>
+      <string>icircumflex</string>
+      <string>idieresis</string>
+      <string>igrave</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>jcircumflex</string>
+      <string>kcommaaccent</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ntilde</string>
+      <string>oacute</string>
+      <string>obreve</string>
+      <string>ocircumflex</string>
+      <string>odieresis</string>
+      <string>ograve</string>
+      <string>ohorn</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
+      <string>oslash</string>
+      <string>oslashacute</string>
+      <string>otilde</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scircumflex</string>
+      <string>tbar</string>
+      <string>tcaron</string>
+      <string>uacute</string>
+      <string>ubreve</string>
+      <string>ucircumflex</string>
+      <string>udieresis</string>
+      <string>ugrave</string>
+      <string>uhorn</string>
+      <string>uhungarumlaut</string>
+      <string>umacron</string>
+      <string>uogonek</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>wacute</string>
+      <string>wcircumflex</string>
+      <string>wdieresis</string>
+      <string>wgrave</string>
+      <string>yacute</string>
+      <string>ycircumflex</string>
+      <string>ydieresis</string>
+      <string>ygrave</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>circumflex</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>breve</string>
+      <string>dotaccent</string>
+      <string>dieresis</string>
+      <string>ring</string>
+      <string>hungarumlaut</string>
+      <string>caron</string>
+      <string>dotbelow</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
+      <string>commaaccent</string>
+      <string>.notdef</string>
+      <string>nonmarkingreturn</string>
+      <string>guillemotleft</string>
+      <string>mu</string>
+      <string>guillemotright</string>
       <string>dotlessi</string>
       <string>IJ</string>
       <string>ij</string>
-      <string>kgreenlandic</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Eng</string>
-      <string>eng</string>
-      <string>OE</string>
-      <string>oe</string>
       <string>longs</string>
-      <string>florin</string>
-      <string>Ohorn</string>
-      <string>ohorn</string>
-      <string>Uhorn</string>
-      <string>uhorn</string>
       <string>uni0237</string>
-      <string>schwa</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
       <string>uni02F3</string>
       <string>gravecomb</string>
       <string>acutecomb</string>
       <string>tildecomb</string>
       <string>hook</string>
       <string>uni030F</string>
-      <string>dotbelow</string>
       <string>tonos</string>
       <string>dieresistonos</string>
       <string>anoteleia</string>
@@ -366,34 +583,15 @@
       <string>uni2009</string>
       <string>uni200A</string>
       <string>uni200B</string>
-      <string>endash</string>
-      <string>emdash</string>
       <string>underscoredbl</string>
-      <string>quoteleft</string>
-      <string>quoteright</string>
-      <string>quotesinglbase</string>
       <string>quotereversed</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>quotedblbase</string>
-      <string>dagger</string>
-      <string>daggerdbl</string>
-      <string>bullet</string>
       <string>uni2025</string>
-      <string>ellipsis</string>
-      <string>perthousand</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
       <string>uni2074</string>
       <string>nsuperior</string>
-      <string>lira</string>
-      <string>peseta</string>
       <string>Euro</string>
       <string>uni2105</string>
       <string>uni2113</string>
       <string>uni2116</string>
-      <string>trademark</string>
       <string>estimated</string>
       <string>oneeighth</string>
       <string>threeeighths</string>
@@ -402,16 +600,10 @@
       <string>partialdiff</string>
       <string>product</string>
       <string>summation</string>
-      <string>minus</string>
       <string>radical</string>
       <string>infinity</string>
       <string>integral</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>lessequal</string>
-      <string>greaterequal</string>
       <string>lozenge</string>
-      <string>commaaccent</string>
       <string>uniFEFF</string>
       <string>uniFFFC</string>
       <string>uniFFFD</string>
@@ -466,186 +658,18 @@
       <string>Germandbls.smcp</string>
       <string>nonbreakingspace</string>
       <string>uni00AD</string>
-      <string>Dcroat</string>
-      <string>Eth</string>
-      <string>hbar</string>
-      <string>Tbar</string>
-      <string>tbar</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>Aringacute</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
-      <string>Iacute</string>
-      <string>Icircumflex</string>
-      <string>Idieresis</string>
-      <string>Ntilde</string>
-      <string>Ograve</string>
-      <string>Oacute</string>
-      <string>Ocircumflex</string>
-      <string>Otilde</string>
-      <string>Odieresis</string>
-      <string>Ugrave</string>
-      <string>Uacute</string>
-      <string>Ucircumflex</string>
-      <string>Udieresis</string>
-      <string>Yacute</string>
-      <string>agrave</string>
-      <string>aacute</string>
-      <string>acircumflex</string>
-      <string>atilde</string>
-      <string>adieresis</string>
-      <string>aring</string>
-      <string>aringacute</string>
-      <string>ccedilla</string>
-      <string>egrave</string>
-      <string>eacute</string>
-      <string>ecircumflex</string>
-      <string>edieresis</string>
-      <string>igrave</string>
-      <string>iacute</string>
-      <string>icircumflex</string>
-      <string>idieresis</string>
-      <string>ntilde</string>
-      <string>ograve</string>
-      <string>oacute</string>
-      <string>ocircumflex</string>
-      <string>otilde</string>
-      <string>odieresis</string>
-      <string>ugrave</string>
-      <string>uacute</string>
-      <string>ucircumflex</string>
-      <string>udieresis</string>
-      <string>yacute</string>
-      <string>ydieresis</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Ccircumflex</string>
-      <string>ccircumflex</string>
       <string>uni010A</string>
       <string>uni010B</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Ebreve</string>
-      <string>ebreve</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Gcircumflex</string>
-      <string>gcircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
       <string>uni0120</string>
       <string>uni0121</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Hcircumflex</string>
-      <string>hcircumflex</string>
-      <string>Itilde</string>
-      <string>itilde</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Ibreve</string>
-      <string>ibreve</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Idotaccent</string>
-      <string>Jcircumflex</string>
-      <string>jcircumflex</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
       <string>napostrophe</string>
-      <string>Omacron</string>
-      <string>omacron</string>
-      <string>Obreve</string>
-      <string>obreve</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Rcommaaccent</string>
-      <string>rcommaaccent</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Scircumflex</string>
-      <string>scircumflex</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
       <string>uni0218</string>
       <string>uni0219</string>
-      <string>Scaron</string>
-      <string>scaron</string>
       <string>uni021A</string>
       <string>uni021B</string>
       <string>uni0162</string>
       <string>uni0162.smcp</string>
       <string>uni0163</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Utilde</string>
-      <string>utilde</string>
-      <string>Umacron</string>
-      <string>umacron</string>
-      <string>Ubreve</string>
-      <string>ubreve</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Uhungarumlaut</string>
-      <string>uhungarumlaut</string>
-      <string>Uogonek</string>
-      <string>uogonek</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Ycircumflex</string>
-      <string>ycircumflex</string>
-      <string>Ydieresis</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>AEacute</string>
-      <string>aeacute</string>
-      <string>Oslashacute</string>
-      <string>oslashacute</string>
       <string>Dcroat.smcp</string>
       <string>Eth.smcp</string>
       <string>Tbar.smcp</string>
@@ -807,16 +831,6 @@
       <string>uni0458</string>
       <string>uni045C</string>
       <string>uni045E</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
-      <string>wacute</string>
-      <string>Wdieresis</string>
-      <string>wdieresis</string>
-      <string>Ygrave</string>
-      <string>ygrave</string>
-      <string>minute</string>
-      <string>second</string>
       <string>exclamdbl</string>
       <string>uni01F0</string>
       <string>uni02BC</string>
@@ -973,7 +987,6 @@
       <string>uni1EF7</string>
       <string>uni1EF8</string>
       <string>uni1EF9</string>
-      <string>dcroat</string>
       <string>uni20AB</string>
       <string>uni049A</string>
       <string>uni049B</string>
@@ -1014,9 +1027,7 @@
       <string>uni04FE</string>
       <string>uni04FF</string>
       <string>uni0511</string>
-      <string>franc</string>
       <string>uni2015</string>
-      <string>exclam</string>
     </array>
   </dict>
 </plist>

--- a/sources/RobotoMono-Thin.ufo/glyphs/D_croat.glif
+++ b/sources/RobotoMono-Thin.ufo/glyphs/D_croat.glif
@@ -1,51 +1,51 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Dcroat" format="2">
-  <advance width="1259"/>
+  <advance width="1229"/>
   <unicode hex="0110"/>
   <outline>
     <contour>
-      <point x="230" y="0" type="line"/>
-      <point x="230" y="713" type="line"/>
-      <point x="-45" y="713" type="line"/>
-      <point x="-45" y="767" type="line"/>
-      <point x="230" y="767" type="line"/>
-      <point x="230" y="1456" type="line"/>
-      <point x="596" y="1456" type="line" smooth="yes"/>
-      <point x="711" y="1453"/>
-      <point x="904" y="1358"/>
-      <point x="965" y="1288" type="qcurve" smooth="yes"/>
-      <point x="1053" y="1186"/>
-      <point x="1138" y="948"/>
-      <point x="1140" y="817" type="qcurve" smooth="yes"/>
-      <point x="1140" y="639" type="line" smooth="yes"/>
-      <point x="1140.0" y="515"/>
-      <point x="1058" y="282"/>
-      <point x="980" y="186" type="qcurve" smooth="yes"/>
-      <point x="911" y="102"/>
-      <point x="716.5873885277105" y="2.8373503182990714"/>
-      <point x="596" y="0" type="qcurve" smooth="yes"/>
+      <point x="215" y="0" type="line"/>
+      <point x="215" y="713" type="line"/>
+      <point x="-60" y="713" type="line"/>
+      <point x="-60" y="767" type="line"/>
+      <point x="215" y="767" type="line"/>
+      <point x="215" y="1456" type="line"/>
+      <point x="581" y="1456" type="line" smooth="yes"/>
+      <point x="696" y="1453"/>
+      <point x="889" y="1358"/>
+      <point x="950" y="1288" type="qcurve" smooth="yes"/>
+      <point x="1038" y="1186"/>
+      <point x="1123" y="948"/>
+      <point x="1125" y="817" type="qcurve" smooth="yes"/>
+      <point x="1125" y="639" type="line" smooth="yes"/>
+      <point x="1125.0" y="515"/>
+      <point x="1043" y="282"/>
+      <point x="965" y="186" type="qcurve" smooth="yes"/>
+      <point x="896" y="102"/>
+      <point x="702" y="3"/>
+      <point x="581" y="0" type="qcurve" smooth="yes"/>
     </contour>
     <contour>
-      <point x="542" y="713" type="line"/>
-      <point x="282" y="713" type="line"/>
-      <point x="282" y="54" type="line"/>
-      <point x="596" y="54" type="line" smooth="yes"/>
-      <point x="708.5126737084885" y="56.8849403514997"/>
-      <point x="883" y="151"/>
-      <point x="945" y="227" type="qcurve" smooth="yes"/>
-      <point x="1012" y="309"/>
-      <point x="1084.4229455803145" y="525.4520817826366"/>
-      <point x="1086" y="639" type="qcurve" smooth="yes"/>
-      <point x="1086" y="820" type="line" smooth="yes"/>
-      <point x="1084" y="940"/>
-      <point x="998" y="1166"/>
-      <point x="921" y="1253" type="qcurve" smooth="yes"/>
-      <point x="864" y="1318"/>
-      <point x="695" y="1402"/>
-      <point x="596" y="1402" type="qcurve" smooth="yes"/>
-      <point x="282" y="1402" type="line"/>
-      <point x="282" y="767" type="line"/>
-      <point x="542" y="767" type="line"/>
+      <point x="527" y="713" type="line"/>
+      <point x="267" y="713" type="line"/>
+      <point x="267" y="54" type="line"/>
+      <point x="581" y="54" type="line" smooth="yes"/>
+      <point x="694" y="57"/>
+      <point x="868" y="151"/>
+      <point x="930" y="227" type="qcurve" smooth="yes"/>
+      <point x="997" y="309"/>
+      <point x="1069" y="525"/>
+      <point x="1071" y="639" type="qcurve" smooth="yes"/>
+      <point x="1071" y="820" type="line" smooth="yes"/>
+      <point x="1069" y="940"/>
+      <point x="983" y="1166"/>
+      <point x="906" y="1253" type="qcurve" smooth="yes"/>
+      <point x="849" y="1318"/>
+      <point x="680" y="1402"/>
+      <point x="581" y="1402" type="qcurve" smooth="yes"/>
+      <point x="267" y="1402" type="line"/>
+      <point x="267" y="767" type="line"/>
+      <point x="527" y="767" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Thin.ufo/glyphs/E_psilontonos.glif
+++ b/sources/RobotoMono-Thin.ufo/glyphs/E_psilontonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Epsilontonos" format="2">
-  <advance width="1329"/>
+  <advance width="1229"/>
   <unicode hex="0388"/>
   <outline>
-    <component base="E" xOffset="100"/>
-    <component base="tonos" xOffset="-516" yOffset="1"/>
+    <component base="E" xOffset="80"/>
+    <component base="tonos" xOffset="-536" yOffset="1"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Thin.ufo/glyphs/E_tatonos.glif
+++ b/sources/RobotoMono-Thin.ufo/glyphs/E_tatonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etatonos" format="2">
-  <advance width="1329"/>
+  <advance width="1229"/>
   <unicode hex="0389"/>
   <outline>
-    <component base="H" xOffset="100"/>
-    <component base="tonos" xOffset="-535" yOffset="1"/>
+    <component base="H" xOffset="80"/>
+    <component base="tonos" xOffset="-555" yOffset="1"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Thin.ufo/glyphs/E_th.glif
+++ b/sources/RobotoMono-Thin.ufo/glyphs/E_th.glif
@@ -1,51 +1,51 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Eth" format="2">
-  <advance width="1259"/>
+  <advance width="1229"/>
   <unicode hex="00D0"/>
   <outline>
     <contour>
-      <point x="230" y="0" type="line"/>
-      <point x="230" y="713" type="line"/>
-      <point x="-45" y="713" type="line"/>
-      <point x="-45" y="767" type="line"/>
-      <point x="230" y="767" type="line"/>
-      <point x="230" y="1456" type="line"/>
-      <point x="596" y="1456" type="line" smooth="yes"/>
-      <point x="711.3528482036456" y="1452.8823554539556"/>
-      <point x="897" y="1363"/>
-      <point x="974" y="1278" type="qcurve" smooth="yes"/>
-      <point x="1048" y="1197"/>
-      <point x="1138" y="946"/>
-      <point x="1140" y="817" type="qcurve" smooth="yes"/>
-      <point x="1140" y="639" type="line" smooth="yes"/>
-      <point x="1140" y="516"/>
-      <point x="1058" y="280"/>
-      <point x="983" y="189" type="qcurve" smooth="yes"/>
-      <point x="912" y="103"/>
-      <point x="717" y="3"/>
-      <point x="596" y="0" type="qcurve" smooth="yes"/>
+      <point x="215" y="0" type="line"/>
+      <point x="215" y="713" type="line"/>
+      <point x="-60" y="713" type="line"/>
+      <point x="-60" y="767" type="line"/>
+      <point x="215" y="767" type="line"/>
+      <point x="215" y="1456" type="line"/>
+      <point x="581" y="1456" type="line" smooth="yes"/>
+      <point x="696" y="1453"/>
+      <point x="882" y="1363"/>
+      <point x="959" y="1278" type="qcurve" smooth="yes"/>
+      <point x="1033" y="1197"/>
+      <point x="1123" y="946"/>
+      <point x="1125" y="817" type="qcurve" smooth="yes"/>
+      <point x="1125" y="639" type="line" smooth="yes"/>
+      <point x="1125" y="516"/>
+      <point x="1043" y="280"/>
+      <point x="968" y="189" type="qcurve" smooth="yes"/>
+      <point x="897" y="103"/>
+      <point x="702" y="3"/>
+      <point x="581" y="0" type="qcurve" smooth="yes"/>
     </contour>
     <contour>
-      <point x="542" y="713" type="line"/>
-      <point x="282" y="713" type="line"/>
-      <point x="282" y="54" type="line"/>
-      <point x="596" y="54" type="line" smooth="yes"/>
-      <point x="707" y="57"/>
-      <point x="884" y="151"/>
-      <point x="943" y="225" type="qcurve" smooth="yes"/>
-      <point x="1011" y="310"/>
-      <point x="1084" y="524"/>
-      <point x="1086" y="639" type="qcurve" smooth="yes"/>
-      <point x="1086" y="820" type="line" smooth="yes"/>
-      <point x="1084" y="935"/>
-      <point x="1008" y="1150"/>
-      <point x="936" y="1239" type="qcurve" smooth="yes"/>
-      <point x="885" y="1302"/>
-      <point x="706" y="1402.0"/>
-      <point x="596" y="1402" type="qcurve" smooth="yes"/>
-      <point x="282" y="1402" type="line"/>
-      <point x="282" y="767" type="line"/>
-      <point x="542" y="767" type="line"/>
+      <point x="527" y="713" type="line"/>
+      <point x="267" y="713" type="line"/>
+      <point x="267" y="54" type="line"/>
+      <point x="581" y="54" type="line" smooth="yes"/>
+      <point x="692" y="57"/>
+      <point x="869" y="151"/>
+      <point x="928" y="225" type="qcurve" smooth="yes"/>
+      <point x="996" y="310"/>
+      <point x="1069" y="524"/>
+      <point x="1071" y="639" type="qcurve" smooth="yes"/>
+      <point x="1071" y="820" type="line" smooth="yes"/>
+      <point x="1069" y="935"/>
+      <point x="993" y="1150"/>
+      <point x="921" y="1239" type="qcurve" smooth="yes"/>
+      <point x="870" y="1302"/>
+      <point x="691" y="1402.0"/>
+      <point x="581" y="1402" type="qcurve" smooth="yes"/>
+      <point x="267" y="1402" type="line"/>
+      <point x="267" y="767" type="line"/>
+      <point x="527" y="767" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Thin.ufo/glyphs/I_circumflex.glif
+++ b/sources/RobotoMono-Thin.ufo/glyphs/I_circumflex.glif
@@ -4,7 +4,6 @@
   <unicode hex="00CE"/>
   <outline>
     <component base="I"/>
-    <component base="circumflex" xOffset="-3" yOffset="319"/>
-    <component base="circumflex" xOffset="-21" yOffset="319"/>
+    <component base="circumflex" xOffset="-27" yOffset="319"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Thin.ufo/glyphs/I_otatonos.glif
+++ b/sources/RobotoMono-Thin.ufo/glyphs/I_otatonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Iotatonos" format="2">
-  <advance width="1329"/>
+  <advance width="1229"/>
   <unicode hex="038A"/>
   <outline>
-    <component base="I" xOffset="100"/>
-    <component base="tonos" xOffset="-551" yOffset="1"/>
+    <component base="I" xOffset="80"/>
+    <component base="tonos" xOffset="-571" yOffset="1"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Thin.ufo/glyphs/O_megatonos.glif
+++ b/sources/RobotoMono-Thin.ufo/glyphs/O_megatonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegatonos" format="2">
-  <advance width="1249"/>
+  <advance width="1229"/>
   <unicode hex="038F"/>
   <outline>
-    <component base="Omega" xOffset="20"/>
-    <component base="tonos" xOffset="-565" yOffset="-1"/>
+    <component base="Omega" xOffset="10"/>
+    <component base="tonos" xOffset="-575" yOffset="-1"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Thin.ufo/glyphs/O_microntonos.glif
+++ b/sources/RobotoMono-Thin.ufo/glyphs/O_microntonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omicrontonos" format="2">
-  <advance width="1249"/>
+  <advance width="1229"/>
   <unicode hex="038C"/>
   <outline>
-    <component base="O" xOffset="20"/>
-    <component base="tonos" xOffset="-559" yOffset="-1"/>
+    <component base="O" xOffset="10"/>
+    <component base="tonos" xOffset="-569" yOffset="-1"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Thin.ufo/glyphs/U_psilontonos.glif
+++ b/sources/RobotoMono-Thin.ufo/glyphs/U_psilontonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Upsilontonos" format="2">
-  <advance width="1329"/>
+  <advance width="1229"/>
   <unicode hex="038E"/>
   <outline>
-    <component base="Y" xOffset="100"/>
-    <component base="tonos" xOffset="-619" yOffset="-1"/>
+    <component base="Y" xOffset="80"/>
+    <component base="tonos" xOffset="-639" yOffset="-1"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Thin.ufo/glyphs/dcaron.glif
+++ b/sources/RobotoMono-Thin.ufo/glyphs/dcaron.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="dcaron" format="2">
-  <advance width="1379"/>
+  <advance width="1229"/>
   <unicode hex="010F"/>
   <outline>
-    <component base="d"/>
-    <component base="quoteright" xOffset="668"/>
+    <component base="d" xOffset="-20"/>
+    <component base="quoteright" xOffset="628"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Thin.ufo/glyphs/dcroat.glif
+++ b/sources/RobotoMono-Thin.ufo/glyphs/dcroat.glif
@@ -1,75 +1,75 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="dcroat" format="2">
-  <advance width="1259"/>
+  <advance width="1229"/>
   <unicode hex="0111"/>
   <outline>
     <contour>
-      <point x="1190" y="1281" type="line"/>
-      <point x="1005" y="1281" type="line"/>
-      <point x="1005" y="0" type="line"/>
-      <point x="951" y="0" type="line"/>
-      <point x="951" y="162" type="line"/>
-      <point x="923" y="118"/>
-      <point x="844" y="51"/>
-      <point x="798" y="28" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="751" y="4"/>
-      <point x="651" y="-20"/>
-      <point x="602" y="-20" type="qcurve" smooth="yes"/>
-      <point x="497.13057741023886" y="-20.0"/>
-      <point x="344" y="64"/>
-      <point x="295" y="128" type="qcurve" smooth="yes"/>
-      <point x="233" y="209"/>
-      <point x="176.0" y="426.6150268585063"/>
-      <point x="176" y="531" type="qcurve" smooth="yes"/>
-      <point x="176" y="552" type="line" smooth="yes"/>
-      <point x="176" y="647"/>
-      <point x="220" y="843"/>
-      <point x="272" y="922" type="qcurve" smooth="yes"/>
-      <point x="322" y="1002"/>
-      <point x="485" y="1102"/>
-      <point x="604" y="1102" type="qcurve" smooth="yes"/>
-      <point x="657" y="1102"/>
-      <point x="758" y="1073"/>
-      <point x="803" y="1046" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="848" y="1019"/>
-      <point x="924" y="943"/>
-      <point x="951" y="896" type="qcurve"/>
-      <point x="951" y="1281" type="line"/>
-      <point x="603" y="1281" type="line"/>
-      <point x="603" y="1335" type="line"/>
-      <point x="951" y="1335" type="line"/>
-      <point x="951" y="1536" type="line"/>
-      <point x="1005" y="1536" type="line"/>
-      <point x="1005" y="1335" type="line"/>
-      <point x="1190" y="1335" type="line"/>
+      <point x="1175" y="1281" type="line"/>
+      <point x="990" y="1281" type="line"/>
+      <point x="990" y="0" type="line"/>
+      <point x="936" y="0" type="line"/>
+      <point x="936" y="162" type="line"/>
+      <point x="908" y="118"/>
+      <point x="829" y="51"/>
+      <point x="783" y="28" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="736" y="4"/>
+      <point x="636" y="-20"/>
+      <point x="587" y="-20" type="qcurve" smooth="yes"/>
+      <point x="482" y="-20.0"/>
+      <point x="329" y="64"/>
+      <point x="280" y="128" type="qcurve" smooth="yes"/>
+      <point x="218" y="209"/>
+      <point x="161.0" y="427"/>
+      <point x="161" y="531" type="qcurve" smooth="yes"/>
+      <point x="161" y="552" type="line" smooth="yes"/>
+      <point x="161" y="647"/>
+      <point x="205" y="843"/>
+      <point x="257" y="922" type="qcurve" smooth="yes"/>
+      <point x="307" y="1002"/>
+      <point x="470" y="1102"/>
+      <point x="589" y="1102" type="qcurve" smooth="yes"/>
+      <point x="642" y="1102"/>
+      <point x="743" y="1073"/>
+      <point x="788" y="1046" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="833" y="1019"/>
+      <point x="909" y="943"/>
+      <point x="936" y="896" type="qcurve"/>
+      <point x="936" y="1281" type="line"/>
+      <point x="588" y="1281" type="line"/>
+      <point x="588" y="1335" type="line"/>
+      <point x="936" y="1335" type="line"/>
+      <point x="936" y="1536" type="line"/>
+      <point x="990" y="1536" type="line"/>
+      <point x="990" y="1335" type="line"/>
+      <point x="1175" y="1335" type="line"/>
     </contour>
     <contour>
-      <point x="232" y="531" type="line" smooth="yes"/>
-      <point x="232.0" y="440.224143420399"/>
-      <point x="275" y="256"/>
-      <point x="329" y="172" type="qcurve" smooth="yes"/>
-      <point x="366" y="114"/>
-      <point x="505.10571357117726" y="34.0"/>
-      <point x="601" y="34" type="qcurve" smooth="yes"/>
-      <point x="654" y="34"/>
-      <point x="761" y="63"/>
-      <point x="808" y="91" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="855" y="119"/>
-      <point x="930" y="202"/>
-      <point x="951" y="255" type="qcurve"/>
-      <point x="951" y="790" type="line"/>
-      <point x="932" y="848"/>
-      <point x="862" y="943"/>
-      <point x="817" y="977" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="771" y="1011"/>
-      <point x="662" y="1048"/>
-      <point x="603" y="1048" type="qcurve" smooth="yes"/>
-      <point x="493" y="1048"/>
-      <point x="349" y="949"/>
-      <point x="309" y="878" type="qcurve" smooth="yes"/>
-      <point x="268" y="806"/>
-      <point x="232" y="633"/>
-      <point x="232" y="552" type="qcurve" smooth="yes"/>
+      <point x="217" y="531" type="line" smooth="yes"/>
+      <point x="217.0" y="440"/>
+      <point x="260" y="256"/>
+      <point x="314" y="172" type="qcurve" smooth="yes"/>
+      <point x="351" y="114"/>
+      <point x="490" y="34.0"/>
+      <point x="586" y="34" type="qcurve" smooth="yes"/>
+      <point x="639" y="34"/>
+      <point x="746" y="63"/>
+      <point x="793" y="91" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="840" y="119"/>
+      <point x="915" y="202"/>
+      <point x="936" y="255" type="qcurve"/>
+      <point x="936" y="790" type="line"/>
+      <point x="917" y="848"/>
+      <point x="847" y="943"/>
+      <point x="802" y="977" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="756" y="1011"/>
+      <point x="647" y="1048"/>
+      <point x="588" y="1048" type="qcurve" smooth="yes"/>
+      <point x="478" y="1048"/>
+      <point x="334" y="949"/>
+      <point x="294" y="878" type="qcurve" smooth="yes"/>
+      <point x="253" y="806"/>
+      <point x="217" y="633"/>
+      <point x="217" y="552" type="qcurve" smooth="yes"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Thin.ufo/glyphs/exclamdbl.glif
+++ b/sources/RobotoMono-Thin.ufo/glyphs/exclamdbl.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="exclamdbl" format="2">
-  <advance width="2458"/>
+  <advance width="1229"/>
   <unicode hex="203C"/>
   <outline>
-    <component base="exclam"/>
-    <component base="exclam" xOffset="1229"/>
+    <component base="exclam" xOffset="-363"/>
+    <component base="exclam" xOffset="393"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Thin.ufo/glyphs/f.glif
+++ b/sources/RobotoMono-Thin.ufo/glyphs/f.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f" format="2">
-  <advance width="1230"/>
+  <advance width="1229"/>
   <unicode hex="0066"/>
   <outline>
     <contour>

--- a/sources/RobotoMono-Thin.ufo/glyphs/hbar.glif
+++ b/sources/RobotoMono-Thin.ufo/glyphs/hbar.glif
@@ -1,49 +1,49 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="hbar" format="2">
-  <advance width="1259"/>
+  <advance width="1229"/>
   <unicode hex="0127"/>
   <outline>
     <contour>
-      <point x="608" y="1281" type="line"/>
-      <point x="298" y="1281" type="line"/>
-      <point x="298" y="821" type="line"/>
-      <point x="324" y="881"/>
-      <point x="404" y="984"/>
-      <point x="455.5" y="1021.5" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="507" y="1059"/>
-      <point x="631" y="1102"/>
-      <point x="702" y="1102" type="qcurve" smooth="yes"/>
-      <point x="795" y="1102"/>
-      <point x="931" y="1042"/>
-      <point x="975.0" y="988.5" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="1019" y="935"/>
-      <point x="1062" y="787"/>
-      <point x="1063" y="700" type="qcurve" smooth="yes"/>
-      <point x="1063" y="0" type="line"/>
-      <point x="1008" y="0" type="line"/>
-      <point x="1008" y="700" type="line" smooth="yes"/>
-      <point x="1007" y="776"/>
-      <point x="972" y="905"/>
-      <point x="934.5" y="951.5" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="897" y="998"/>
-      <point x="781" y="1050"/>
-      <point x="699" y="1049" type="qcurve" smooth="yes"/>
-      <point x="626" y="1048"/>
-      <point x="494" y="992"/>
-      <point x="440.5" y="945.0" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="387" y="898"/>
-      <point x="313" y="772"/>
-      <point x="298" y="702" type="qcurve"/>
-      <point x="298" y="0" type="line"/>
-      <point x="243" y="0" type="line"/>
-      <point x="243" y="1281" type="line"/>
-      <point x="21" y="1281" type="line"/>
-      <point x="21" y="1335" type="line"/>
-      <point x="243" y="1335" type="line"/>
-      <point x="243" y="1536" type="line"/>
-      <point x="298" y="1536" type="line"/>
-      <point x="298" y="1335" type="line"/>
-      <point x="608" y="1335" type="line"/>
+      <point x="593" y="1281" type="line"/>
+      <point x="283" y="1281" type="line"/>
+      <point x="283" y="821" type="line"/>
+      <point x="309" y="881"/>
+      <point x="389" y="984"/>
+      <point x="441" y="1022" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="492" y="1059"/>
+      <point x="616" y="1102"/>
+      <point x="687" y="1102" type="qcurve" smooth="yes"/>
+      <point x="780" y="1102"/>
+      <point x="916" y="1042"/>
+      <point x="960.0" y="989" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="1004" y="935"/>
+      <point x="1047" y="787"/>
+      <point x="1048" y="700" type="qcurve" smooth="yes"/>
+      <point x="1048" y="0" type="line"/>
+      <point x="993" y="0" type="line"/>
+      <point x="993" y="700" type="line" smooth="yes"/>
+      <point x="992" y="776"/>
+      <point x="957" y="905"/>
+      <point x="920" y="952" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="882" y="998"/>
+      <point x="766" y="1050"/>
+      <point x="684" y="1049" type="qcurve" smooth="yes"/>
+      <point x="611" y="1048"/>
+      <point x="479" y="992"/>
+      <point x="426" y="945.0" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="372" y="898"/>
+      <point x="298" y="772"/>
+      <point x="283" y="702" type="qcurve"/>
+      <point x="283" y="0" type="line"/>
+      <point x="228" y="0" type="line"/>
+      <point x="228" y="1281" type="line"/>
+      <point x="6" y="1281" type="line"/>
+      <point x="6" y="1335" type="line"/>
+      <point x="228" y="1335" type="line"/>
+      <point x="228" y="1536" type="line"/>
+      <point x="283" y="1536" type="line"/>
+      <point x="283" y="1335" type="line"/>
+      <point x="593" y="1335" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Thin.ufo/glyphs/hyphen.glif
+++ b/sources/RobotoMono-Thin.ufo/glyphs/hyphen.glif
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="hyphen" format="2">
-  <advance width="1230"/>
+  <advance width="1229"/>
   <unicode hex="002D"/>
   <outline>
     <contour>
-      <point x="958" y="639" type="line"/>
-      <point x="240" y="639" type="line"/>
-      <point x="240" y="693" type="line"/>
-      <point x="958" y="693" type="line"/>
+      <point x="974" y="639" type="line"/>
+      <point x="256" y="639" type="line"/>
+      <point x="256" y="693" type="line"/>
+      <point x="974" y="693" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Thin.ufo/glyphs/lcaron.glif
+++ b/sources/RobotoMono-Thin.ufo/glyphs/lcaron.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="lcaron" format="2">
-  <advance width="1379"/>
+  <advance width="1229"/>
   <unicode hex="013E"/>
   <outline>
-    <component base="l"/>
-    <component base="quoteright" xOffset="392" yOffset="2"/>
+    <component base="l" xOffset="-30"/>
+    <component base="quoteright" xOffset="362" yOffset="2"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Thin.ufo/glyphs/ldot.glif
+++ b/sources/RobotoMono-Thin.ufo/glyphs/ldot.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ldot" format="2">
-  <advance width="1449"/>
+  <advance width="1229"/>
   <unicode hex="0140"/>
   <outline>
-    <component base="l"/>
-    <component base="dotaccent" xOffset="291" yOffset="-571"/>
+    <component base="l" xOffset="-20"/>
+    <component base="dotaccent" xOffset="271" yOffset="-571"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Thin.ufo/glyphs/tcaron.glif
+++ b/sources/RobotoMono-Thin.ufo/glyphs/tcaron.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="tcaron" format="2">
-  <advance width="1269"/>
+  <advance width="1229"/>
   <unicode hex="0165"/>
   <outline>
-    <component base="t"/>
-    <component base="quoteright" xOffset="317" yOffset="23"/>
+    <component base="t" xOffset="-20"/>
+    <component base="quoteright" xOffset="297" yOffset="23"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Thin.ufo/glyphs/uni00A_D_.glif
+++ b/sources/RobotoMono-Thin.ufo/glyphs/uni00A_D_.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni00AD" format="2">
-  <advance width="1230"/>
+  <advance width="1229"/>
   <unicode hex="00AD"/>
   <outline>
     <component base="hyphen"/>

--- a/sources/RobotoMono-Thin.ufo/glyphs/uni0483.glif
+++ b/sources/RobotoMono-Thin.ufo/glyphs/uni0483.glif
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni0483" format="2">
+  <advance width="1229"/>
   <unicode hex="0483"/>
   <outline>
     <contour>

--- a/sources/RobotoMono-Thin.ufo/glyphs/uni0484.glif
+++ b/sources/RobotoMono-Thin.ufo/glyphs/uni0484.glif
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni0484" format="2">
+  <advance width="1229"/>
   <unicode hex="0484"/>
   <outline>
     <contour>

--- a/sources/RobotoMono-Thin.ufo/glyphs/uni0485.glif
+++ b/sources/RobotoMono-Thin.ufo/glyphs/uni0485.glif
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni0485" format="2">
+  <advance width="1229"/>
   <unicode hex="0485"/>
   <outline>
     <contour>

--- a/sources/RobotoMono-Thin.ufo/glyphs/uni0486.glif
+++ b/sources/RobotoMono-Thin.ufo/glyphs/uni0486.glif
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni0486" format="2">
+  <advance width="1229"/>
   <unicode hex="0486"/>
   <outline>
     <contour>

--- a/sources/RobotoMono-Thin.ufo/glyphs/uni0488.glif
+++ b/sources/RobotoMono-Thin.ufo/glyphs/uni0488.glif
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni0488" format="2">
+  <advance width="1229"/>
   <unicode hex="0488"/>
   <outline>
     <contour>

--- a/sources/RobotoMono-Thin.ufo/glyphs/uni0489.glif
+++ b/sources/RobotoMono-Thin.ufo/glyphs/uni0489.glif
@@ -1,62 +1,63 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni0489" format="2">
+  <advance width="1229"/>
   <unicode hex="0489"/>
   <outline>
     <contour>
-      <point x="1105" y="-60" type="line"/>
-      <point x="1116" y="-74" type="line"/>
-      <point x="994" y="-413" type="line"/>
-      <point x="898" y="-413" type="line"/>
-      <point x="968" y="-60" type="line"/>
+      <point x="739" y="-60" type="line"/>
+      <point x="750" y="-74" type="line"/>
+      <point x="628" y="-413" type="line"/>
+      <point x="532" y="-413" type="line"/>
+      <point x="602" y="-60" type="line"/>
     </contour>
     <contour>
-      <point x="910" y="1126" type="line"/>
-      <point x="898" y="1140" type="line"/>
-      <point x="1020" y="1478" type="line"/>
-      <point x="1116" y="1478" type="line"/>
-      <point x="1046" y="1126" type="line"/>
+      <point x="544" y="1126" type="line"/>
+      <point x="532" y="1140" type="line"/>
+      <point x="654" y="1478" type="line"/>
+      <point x="750" y="1478" type="line"/>
+      <point x="680" y="1126" type="line"/>
     </contour>
     <contour>
-      <point x="1588" y="631" type="line"/>
-      <point x="1601" y="643" type="line"/>
-      <point x="1934" y="519" type="line"/>
-      <point x="1934" y="421" type="line"/>
-      <point x="1588" y="492" type="line"/>
+      <point x="1222" y="631" type="line"/>
+      <point x="1235" y="643" type="line"/>
+      <point x="1568" y="519" type="line"/>
+      <point x="1568" y="421" type="line"/>
+      <point x="1222" y="492" type="line"/>
     </contour>
     <contour>
-      <point x="424" y="433" type="line"/>
-      <point x="411" y="421" type="line"/>
-      <point x="78" y="545" type="line"/>
-      <point x="78" y="643" type="line"/>
-      <point x="424" y="572" type="line"/>
+      <point x="58" y="433" type="line"/>
+      <point x="45" y="421" type="line"/>
+      <point x="-288" y="545" type="line"/>
+      <point x="-288" y="643" type="line"/>
+      <point x="58" y="572" type="line"/>
     </contour>
     <contour>
-      <point x="1348" y="1002" type="line"/>
-      <point x="1350" y="1018" type="line"/>
-      <point x="1671" y="1171" type="line"/>
-      <point x="1739" y="1103" type="line"/>
-      <point x="1445" y="903" type="line"/>
+      <point x="982" y="1002" type="line"/>
+      <point x="984" y="1018" type="line"/>
+      <point x="1305" y="1171" type="line"/>
+      <point x="1373" y="1103" type="line"/>
+      <point x="1079" y="903" type="line"/>
     </contour>
     <contour>
-      <point x="664" y="21" type="line"/>
-      <point x="662" y="4" type="line"/>
-      <point x="342" y="-149" type="line"/>
-      <point x="273" y="-80" type="line"/>
-      <point x="567" y="120" type="line"/>
+      <point x="298" y="21" type="line"/>
+      <point x="296" y="4" type="line"/>
+      <point x="-24" y="-149" type="line"/>
+      <point x="-93" y="-80" type="line"/>
+      <point x="201" y="120" type="line"/>
     </contour>
     <contour>
-      <point x="524" y="860" type="line"/>
-      <point x="507" y="862" type="line"/>
-      <point x="359" y="1188" type="line"/>
-      <point x="424" y="1257" type="line"/>
-      <point x="622" y="958" type="line"/>
+      <point x="158" y="860" type="line"/>
+      <point x="141" y="862" type="line"/>
+      <point x="-7" y="1188" type="line"/>
+      <point x="58" y="1257" type="line"/>
+      <point x="256" y="958" type="line"/>
     </contour>
     <contour>
-      <point x="1486" y="161" type="line"/>
-      <point x="1503" y="159" type="line"/>
-      <point x="1652" y="-166" type="line"/>
-      <point x="1586" y="-237" type="line"/>
-      <point x="1389" y="62" type="line"/>
+      <point x="1120" y="161" type="line"/>
+      <point x="1137" y="159" type="line"/>
+      <point x="1286" y="-166" type="line"/>
+      <point x="1220" y="-237" type="line"/>
+      <point x="1023" y="62" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Thin.ufo/glyphs/uni049E_.glif
+++ b/sources/RobotoMono-Thin.ufo/glyphs/uni049E_.glif
@@ -1,30 +1,30 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni049E" format="2">
-  <advance width="1249"/>
+  <advance width="1229"/>
   <unicode hex="049E"/>
   <outline>
     <contour>
-      <point x="523" y="711" type="line"/>
-      <point x="323" y="711" type="line"/>
-      <point x="323" y="0" type="line"/>
-      <point x="271" y="0" type="line"/>
-      <point x="271" y="1105" type="line"/>
-      <point x="39" y="1105" type="line"/>
-      <point x="39" y="1159" type="line"/>
-      <point x="271" y="1159" type="line"/>
-      <point x="271" y="1456" type="line"/>
-      <point x="323" y="1456" type="line"/>
-      <point x="323" y="1159" type="line"/>
-      <point x="626" y="1159" type="line"/>
-      <point x="626" y="1105" type="line"/>
-      <point x="323" y="1105" type="line"/>
-      <point x="323" y="764" type="line"/>
-      <point x="539" y="764" type="line"/>
-      <point x="1106" y="1456" type="line"/>
-      <point x="1174" y="1456" type="line"/>
-      <point x="582" y="729" type="line"/>
-      <point x="1216" y="0" type="line"/>
-      <point x="1148" y="0" type="line"/>
+      <point x="513" y="711" type="line"/>
+      <point x="313" y="711" type="line"/>
+      <point x="313" y="0" type="line"/>
+      <point x="261" y="0" type="line"/>
+      <point x="261" y="1105" type="line"/>
+      <point x="29" y="1105" type="line"/>
+      <point x="29" y="1159" type="line"/>
+      <point x="261" y="1159" type="line"/>
+      <point x="261" y="1456" type="line"/>
+      <point x="313" y="1456" type="line"/>
+      <point x="313" y="1159" type="line"/>
+      <point x="616" y="1159" type="line"/>
+      <point x="616" y="1105" type="line"/>
+      <point x="313" y="1105" type="line"/>
+      <point x="313" y="764" type="line"/>
+      <point x="529" y="764" type="line"/>
+      <point x="1096" y="1456" type="line"/>
+      <point x="1164" y="1456" type="line"/>
+      <point x="572" y="729" type="line"/>
+      <point x="1206" y="0" type="line"/>
+      <point x="1138" y="0" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Thin.ufo/glyphs/uni049F_.glif
+++ b/sources/RobotoMono-Thin.ufo/glyphs/uni049F_.glif
@@ -1,30 +1,30 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni049F" format="2">
-  <advance width="1249"/>
+  <advance width="1229"/>
   <unicode hex="049F"/>
   <outline>
     <contour>
-      <point x="277" y="0" type="line"/>
-      <point x="277" y="1264" type="line"/>
-      <point x="104" y="1264" type="line"/>
-      <point x="104" y="1318" type="line"/>
-      <point x="277" y="1318" type="line"/>
-      <point x="277" y="1536" type="line"/>
-      <point x="332" y="1536" type="line"/>
-      <point x="332" y="1318" type="line"/>
-      <point x="691" y="1318" type="line"/>
-      <point x="691" y="1264" type="line"/>
-      <point x="332" y="1264" type="line"/>
-      <point x="332" y="505" type="line"/>
-      <point x="469" y="627" type="line"/>
-      <point x="993" y="1082" type="line"/>
-      <point x="1073" y="1082" type="line"/>
-      <point x="545" y="622" type="line"/>
-      <point x="1106" y="0" type="line"/>
-      <point x="1034" y="0" type="line"/>
-      <point x="503" y="586" type="line"/>
-      <point x="332" y="447" type="line"/>
-      <point x="332" y="0" type="line"/>
+      <point x="267" y="0" type="line"/>
+      <point x="267" y="1264" type="line"/>
+      <point x="94" y="1264" type="line"/>
+      <point x="94" y="1318" type="line"/>
+      <point x="267" y="1318" type="line"/>
+      <point x="267" y="1536" type="line"/>
+      <point x="322" y="1536" type="line"/>
+      <point x="322" y="1318" type="line"/>
+      <point x="681" y="1318" type="line"/>
+      <point x="681" y="1264" type="line"/>
+      <point x="322" y="1264" type="line"/>
+      <point x="322" y="505" type="line"/>
+      <point x="459" y="627" type="line"/>
+      <point x="983" y="1082" type="line"/>
+      <point x="1063" y="1082" type="line"/>
+      <point x="535" y="622" type="line"/>
+      <point x="1096" y="0" type="line"/>
+      <point x="1024" y="0" type="line"/>
+      <point x="493" y="586" type="line"/>
+      <point x="322" y="447" type="line"/>
+      <point x="322" y="0" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Thin.ufo/glyphs/uni20A_B_.glif
+++ b/sources/RobotoMono-Thin.ufo/glyphs/uni20A_B_.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni20AB" format="2">
-  <advance width="1259"/>
+  <advance width="1229"/>
   <unicode hex="20AB"/>
   <outline>
-    <component base="d"/>
+    <component base="d" xOffset="-15"/>
     <component base="crossbar" xOffset="267" yOffset="560"/>
-    <component base="underscore" xOffset="-48" yOffset="-156"/>
+    <component base="underscore" xOffset="-63" yOffset="-156"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-Thin.ufo/lib.plist
+++ b/sources/RobotoMono-Thin.ufo/lib.plist
@@ -2,6 +2,17 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
   <dict>
+    <key>com.defcon.sortDescriptor</key>
+    <array>
+      <dict>
+        <key>allowPseudoUnicode</key>
+        <integer>0</integer>
+        <key>ascending</key>
+        <string>Amstelvar DB Best</string>
+        <key>type</key>
+        <string>characterSet</string>
+      </dict>
+    </array>
     <key>com.typemytype.robofont.binarySource</key>
     <string>/Users/pichotta/Downloads/Roboto_Mono/RobotoMono-Thin.ttf</string>
     <key>com.typemytype.robofont.fontIdentifier</key>
@@ -10,41 +21,8 @@
     <string>qcurve</string>
     <key>public.glyphOrder</key>
     <array>
-      <string>.notdef</string>
       <string>NULL</string>
-      <string>nonmarkingreturn</string>
       <string>space</string>
-      <string>quotedbl</string>
-      <string>numbersign</string>
-      <string>dollar</string>
-      <string>percent</string>
-      <string>ampersand</string>
-      <string>quotesingle</string>
-      <string>parenleft</string>
-      <string>parenright</string>
-      <string>asterisk</string>
-      <string>plus</string>
-      <string>comma</string>
-      <string>hyphen</string>
-      <string>period</string>
-      <string>slash</string>
-      <string>zero</string>
-      <string>one</string>
-      <string>two</string>
-      <string>three</string>
-      <string>four</string>
-      <string>five</string>
-      <string>six</string>
-      <string>seven</string>
-      <string>eight</string>
-      <string>nine</string>
-      <string>colon</string>
-      <string>semicolon</string>
-      <string>less</string>
-      <string>equal</string>
-      <string>greater</string>
-      <string>question</string>
-      <string>at</string>
       <string>A</string>
       <string>B</string>
       <string>C</string>
@@ -71,12 +49,6 @@
       <string>X</string>
       <string>Y</string>
       <string>Z</string>
-      <string>bracketleft</string>
-      <string>backslash</string>
-      <string>bracketright</string>
-      <string>asciicircum</string>
-      <string>underscore</string>
-      <string>grave</string>
       <string>a</string>
       <string>b</string>
       <string>c</string>
@@ -103,84 +75,329 @@
       <string>x</string>
       <string>y</string>
       <string>z</string>
-      <string>braceleft</string>
-      <string>bar</string>
-      <string>braceright</string>
-      <string>asciitilde</string>
-      <string>exclamdown</string>
-      <string>cent</string>
-      <string>sterling</string>
-      <string>currency</string>
-      <string>yen</string>
-      <string>brokenbar</string>
-      <string>section</string>
-      <string>dieresis</string>
-      <string>copyright</string>
-      <string>ordfeminine</string>
-      <string>guillemotleft</string>
-      <string>logicalnot</string>
-      <string>registered</string>
-      <string>macron</string>
-      <string>degree</string>
-      <string>plusminus</string>
+      <string>zero</string>
+      <string>one</string>
+      <string>two</string>
+      <string>three</string>
+      <string>four</string>
+      <string>five</string>
+      <string>six</string>
+      <string>seven</string>
+      <string>eight</string>
+      <string>nine</string>
+      <string>onesuperior</string>
       <string>twosuperior</string>
       <string>threesuperior</string>
-      <string>acute</string>
-      <string>mu</string>
-      <string>paragraph</string>
-      <string>periodcentered</string>
-      <string>cedilla</string>
-      <string>onesuperior</string>
+      <string>ordfeminine</string>
       <string>ordmasculine</string>
-      <string>guillemotright</string>
-      <string>onequarter</string>
       <string>onehalf</string>
+      <string>onequarter</string>
       <string>threequarters</string>
-      <string>questiondown</string>
       <string>AE</string>
-      <string>multiply</string>
-      <string>Oslash</string>
-      <string>Thorn</string>
-      <string>germandbls</string>
       <string>ae</string>
+      <string>OE</string>
+      <string>oe</string>
       <string>eth</string>
-      <string>divide</string>
-      <string>oslash</string>
+      <string>Thorn</string>
       <string>thorn</string>
+      <string>kgreenlandic</string>
+      <string>germandbls</string>
+      <string>schwa</string>
+      <string>dollar</string>
+      <string>cent</string>
+      <string>sterling</string>
+      <string>yen</string>
+      <string>florin</string>
+      <string>franc</string>
+      <string>lira</string>
+      <string>peseta</string>
+      <string>currency</string>
+      <string>exclam</string>
+      <string>exclamdown</string>
+      <string>question</string>
+      <string>questiondown</string>
+      <string>comma</string>
+      <string>period</string>
+      <string>colon</string>
+      <string>semicolon</string>
+      <string>ellipsis</string>
+      <string>periodcentered</string>
+      <string>bullet</string>
+      <string>underscore</string>
+      <string>hyphen</string>
+      <string>endash</string>
+      <string>emdash</string>
+      <string>quotesingle</string>
+      <string>quotedbl</string>
+      <string>quoteleft</string>
+      <string>quoteright</string>
+      <string>quotesinglbase</string>
+      <string>quotedblleft</string>
+      <string>quotedblright</string>
+      <string>quotedblbase</string>
+      <string>minute</string>
+      <string>second</string>
+      <string>parenleft</string>
+      <string>parenright</string>
+      <string>bracketleft</string>
+      <string>bracketright</string>
+      <string>braceleft</string>
+      <string>braceright</string>
+      <string>guilsinglleft</string>
+      <string>guilsinglright</string>
+      <string>plus</string>
+      <string>minus</string>
+      <string>plusminus</string>
+      <string>multiply</string>
+      <string>divide</string>
+      <string>equal</string>
+      <string>notequal</string>
+      <string>approxequal</string>
+      <string>less</string>
+      <string>greater</string>
+      <string>lessequal</string>
+      <string>greaterequal</string>
+      <string>logicalnot</string>
+      <string>slash</string>
+      <string>backslash</string>
+      <string>fraction</string>
+      <string>percent</string>
+      <string>perthousand</string>
+      <string>bar</string>
+      <string>brokenbar</string>
+      <string>dagger</string>
+      <string>daggerdbl</string>
+      <string>copyright</string>
+      <string>registered</string>
+      <string>trademark</string>
+      <string>degree</string>
+      <string>asterisk</string>
+      <string>numbersign</string>
+      <string>ampersand</string>
+      <string>at</string>
+      <string>section</string>
+      <string>paragraph</string>
+      <string>asciicircum</string>
+      <string>asciitilde</string>
+      <string>Aacute</string>
+      <string>Abreve</string>
+      <string>Acircumflex</string>
+      <string>Adieresis</string>
+      <string>Agrave</string>
+      <string>Amacron</string>
+      <string>Aogonek</string>
+      <string>Aring</string>
+      <string>Aringacute</string>
+      <string>Atilde</string>
+      <string>AEacute</string>
+      <string>Cacute</string>
+      <string>Ccaron</string>
+      <string>Ccedilla</string>
+      <string>Ccircumflex</string>
+      <string>Dcaron</string>
+      <string>Dcroat</string>
+      <string>Eacute</string>
+      <string>Ebreve</string>
+      <string>Ecaron</string>
+      <string>Ecircumflex</string>
+      <string>Edieresis</string>
+      <string>Edotaccent</string>
+      <string>Egrave</string>
+      <string>Emacron</string>
+      <string>Eng</string>
+      <string>Eogonek</string>
+      <string>Eth</string>
+      <string>Gbreve</string>
+      <string>Gcircumflex</string>
+      <string>Gcommaaccent</string>
       <string>Hbar</string>
+      <string>Hcircumflex</string>
+      <string>Iacute</string>
+      <string>Ibreve</string>
+      <string>Icircumflex</string>
+      <string>Idieresis</string>
+      <string>Idotaccent</string>
+      <string>Igrave</string>
+      <string>Imacron</string>
+      <string>Iogonek</string>
+      <string>Itilde</string>
+      <string>Jcircumflex</string>
+      <string>Kcommaaccent</string>
+      <string>Lacute</string>
+      <string>Lcaron</string>
+      <string>Lcommaaccent</string>
+      <string>Ldot</string>
+      <string>Lslash</string>
+      <string>Nacute</string>
+      <string>Ncaron</string>
+      <string>Ncommaaccent</string>
+      <string>Ntilde</string>
+      <string>Oacute</string>
+      <string>Obreve</string>
+      <string>Ocircumflex</string>
+      <string>Odieresis</string>
+      <string>Ograve</string>
+      <string>Ohorn</string>
+      <string>Ohungarumlaut</string>
+      <string>Omacron</string>
+      <string>Oslash</string>
+      <string>Oslashacute</string>
+      <string>Otilde</string>
+      <string>Racute</string>
+      <string>Rcaron</string>
+      <string>Rcommaaccent</string>
+      <string>Sacute</string>
+      <string>Scaron</string>
+      <string>Scedilla</string>
+      <string>Scircumflex</string>
+      <string>Tbar</string>
+      <string>Tcaron</string>
+      <string>Uacute</string>
+      <string>Ubreve</string>
+      <string>Ucircumflex</string>
+      <string>Udieresis</string>
+      <string>Ugrave</string>
+      <string>Uhorn</string>
+      <string>Uhungarumlaut</string>
+      <string>Umacron</string>
+      <string>Uogonek</string>
+      <string>Uring</string>
+      <string>Utilde</string>
+      <string>Wacute</string>
+      <string>Wcircumflex</string>
+      <string>Wdieresis</string>
+      <string>Wgrave</string>
+      <string>Yacute</string>
+      <string>Ycircumflex</string>
+      <string>Ydieresis</string>
+      <string>Ygrave</string>
+      <string>Zacute</string>
+      <string>Zcaron</string>
+      <string>Zdotaccent</string>
+      <string>aacute</string>
+      <string>abreve</string>
+      <string>acircumflex</string>
+      <string>adieresis</string>
+      <string>agrave</string>
+      <string>amacron</string>
+      <string>aogonek</string>
+      <string>aring</string>
+      <string>aringacute</string>
+      <string>atilde</string>
+      <string>aeacute</string>
+      <string>cacute</string>
+      <string>ccaron</string>
+      <string>ccedilla</string>
+      <string>ccircumflex</string>
+      <string>dcaron</string>
+      <string>dcroat</string>
+      <string>eacute</string>
+      <string>ebreve</string>
+      <string>ecaron</string>
+      <string>ecircumflex</string>
+      <string>edieresis</string>
+      <string>edotaccent</string>
+      <string>egrave</string>
+      <string>emacron</string>
+      <string>eng</string>
+      <string>eogonek</string>
+      <string>gbreve</string>
+      <string>gcircumflex</string>
+      <string>gcommaaccent</string>
+      <string>hbar</string>
+      <string>hcircumflex</string>
+      <string>iacute</string>
+      <string>ibreve</string>
+      <string>icircumflex</string>
+      <string>idieresis</string>
+      <string>igrave</string>
+      <string>imacron</string>
+      <string>iogonek</string>
+      <string>itilde</string>
+      <string>jcircumflex</string>
+      <string>kcommaaccent</string>
+      <string>lacute</string>
+      <string>lcaron</string>
+      <string>lcommaaccent</string>
+      <string>ldot</string>
+      <string>lslash</string>
+      <string>nacute</string>
+      <string>ncaron</string>
+      <string>ncommaaccent</string>
+      <string>ntilde</string>
+      <string>oacute</string>
+      <string>obreve</string>
+      <string>ocircumflex</string>
+      <string>odieresis</string>
+      <string>ograve</string>
+      <string>ohorn</string>
+      <string>ohungarumlaut</string>
+      <string>omacron</string>
+      <string>oslash</string>
+      <string>oslashacute</string>
+      <string>otilde</string>
+      <string>racute</string>
+      <string>rcaron</string>
+      <string>rcommaaccent</string>
+      <string>sacute</string>
+      <string>scaron</string>
+      <string>scedilla</string>
+      <string>scircumflex</string>
+      <string>tbar</string>
+      <string>tcaron</string>
+      <string>uacute</string>
+      <string>ubreve</string>
+      <string>ucircumflex</string>
+      <string>udieresis</string>
+      <string>ugrave</string>
+      <string>uhorn</string>
+      <string>uhungarumlaut</string>
+      <string>umacron</string>
+      <string>uogonek</string>
+      <string>uring</string>
+      <string>utilde</string>
+      <string>wacute</string>
+      <string>wcircumflex</string>
+      <string>wdieresis</string>
+      <string>wgrave</string>
+      <string>yacute</string>
+      <string>ycircumflex</string>
+      <string>ydieresis</string>
+      <string>ygrave</string>
+      <string>zacute</string>
+      <string>zcaron</string>
+      <string>zdotaccent</string>
+      <string>grave</string>
+      <string>acute</string>
+      <string>circumflex</string>
+      <string>tilde</string>
+      <string>macron</string>
+      <string>breve</string>
+      <string>dotaccent</string>
+      <string>dieresis</string>
+      <string>ring</string>
+      <string>hungarumlaut</string>
+      <string>caron</string>
+      <string>dotbelow</string>
+      <string>cedilla</string>
+      <string>ogonek</string>
+      <string>commaaccent</string>
+      <string>.notdef</string>
+      <string>nonmarkingreturn</string>
+      <string>guillemotleft</string>
+      <string>mu</string>
+      <string>guillemotright</string>
       <string>dotlessi</string>
       <string>IJ</string>
       <string>ij</string>
-      <string>kgreenlandic</string>
-      <string>Lslash</string>
-      <string>lslash</string>
-      <string>Eng</string>
-      <string>eng</string>
-      <string>OE</string>
-      <string>oe</string>
       <string>longs</string>
-      <string>florin</string>
-      <string>Ohorn</string>
-      <string>ohorn</string>
-      <string>Uhorn</string>
-      <string>uhorn</string>
       <string>uni0237</string>
-      <string>schwa</string>
-      <string>circumflex</string>
-      <string>caron</string>
-      <string>breve</string>
-      <string>dotaccent</string>
-      <string>ring</string>
-      <string>ogonek</string>
-      <string>tilde</string>
-      <string>hungarumlaut</string>
       <string>uni02F3</string>
       <string>gravecomb</string>
       <string>acutecomb</string>
       <string>tildecomb</string>
       <string>hook</string>
       <string>uni030F</string>
-      <string>dotbelow</string>
       <string>tonos</string>
       <string>dieresistonos</string>
       <string>anoteleia</string>
@@ -366,34 +583,15 @@
       <string>uni2009</string>
       <string>uni200A</string>
       <string>uni200B</string>
-      <string>endash</string>
-      <string>emdash</string>
       <string>underscoredbl</string>
-      <string>quoteleft</string>
-      <string>quoteright</string>
-      <string>quotesinglbase</string>
       <string>quotereversed</string>
-      <string>quotedblleft</string>
-      <string>quotedblright</string>
-      <string>quotedblbase</string>
-      <string>dagger</string>
-      <string>daggerdbl</string>
-      <string>bullet</string>
       <string>uni2025</string>
-      <string>ellipsis</string>
-      <string>perthousand</string>
-      <string>guilsinglleft</string>
-      <string>guilsinglright</string>
-      <string>fraction</string>
       <string>uni2074</string>
       <string>nsuperior</string>
-      <string>lira</string>
-      <string>peseta</string>
       <string>Euro</string>
       <string>uni2105</string>
       <string>uni2113</string>
       <string>uni2116</string>
-      <string>trademark</string>
       <string>estimated</string>
       <string>oneeighth</string>
       <string>threeeighths</string>
@@ -402,16 +600,10 @@
       <string>partialdiff</string>
       <string>product</string>
       <string>summation</string>
-      <string>minus</string>
       <string>radical</string>
       <string>infinity</string>
       <string>integral</string>
-      <string>approxequal</string>
-      <string>notequal</string>
-      <string>lessequal</string>
-      <string>greaterequal</string>
       <string>lozenge</string>
-      <string>commaaccent</string>
       <string>uniFEFF</string>
       <string>uniFFFC</string>
       <string>uniFFFD</string>
@@ -466,186 +658,18 @@
       <string>Germandbls.smcp</string>
       <string>nonbreakingspace</string>
       <string>uni00AD</string>
-      <string>Dcroat</string>
-      <string>Eth</string>
-      <string>hbar</string>
-      <string>Tbar</string>
-      <string>tbar</string>
-      <string>Agrave</string>
-      <string>Aacute</string>
-      <string>Acircumflex</string>
-      <string>Atilde</string>
-      <string>Adieresis</string>
-      <string>Aring</string>
-      <string>Aringacute</string>
-      <string>Ccedilla</string>
-      <string>Egrave</string>
-      <string>Eacute</string>
-      <string>Ecircumflex</string>
-      <string>Edieresis</string>
-      <string>Igrave</string>
-      <string>Iacute</string>
-      <string>Icircumflex</string>
-      <string>Idieresis</string>
-      <string>Ntilde</string>
-      <string>Ograve</string>
-      <string>Oacute</string>
-      <string>Ocircumflex</string>
-      <string>Otilde</string>
-      <string>Odieresis</string>
-      <string>Ugrave</string>
-      <string>Uacute</string>
-      <string>Ucircumflex</string>
-      <string>Udieresis</string>
-      <string>Yacute</string>
-      <string>agrave</string>
-      <string>aacute</string>
-      <string>acircumflex</string>
-      <string>atilde</string>
-      <string>adieresis</string>
-      <string>aring</string>
-      <string>aringacute</string>
-      <string>ccedilla</string>
-      <string>egrave</string>
-      <string>eacute</string>
-      <string>ecircumflex</string>
-      <string>edieresis</string>
-      <string>igrave</string>
-      <string>iacute</string>
-      <string>icircumflex</string>
-      <string>idieresis</string>
-      <string>ntilde</string>
-      <string>ograve</string>
-      <string>oacute</string>
-      <string>ocircumflex</string>
-      <string>otilde</string>
-      <string>odieresis</string>
-      <string>ugrave</string>
-      <string>uacute</string>
-      <string>ucircumflex</string>
-      <string>udieresis</string>
-      <string>yacute</string>
-      <string>ydieresis</string>
-      <string>Amacron</string>
-      <string>amacron</string>
-      <string>Abreve</string>
-      <string>abreve</string>
-      <string>Aogonek</string>
-      <string>aogonek</string>
-      <string>Cacute</string>
-      <string>cacute</string>
-      <string>Ccircumflex</string>
-      <string>ccircumflex</string>
       <string>uni010A</string>
       <string>uni010B</string>
-      <string>Ccaron</string>
-      <string>ccaron</string>
-      <string>Dcaron</string>
-      <string>dcaron</string>
-      <string>Emacron</string>
-      <string>emacron</string>
-      <string>Ebreve</string>
-      <string>ebreve</string>
-      <string>Edotaccent</string>
-      <string>edotaccent</string>
-      <string>Eogonek</string>
-      <string>eogonek</string>
-      <string>Ecaron</string>
-      <string>ecaron</string>
-      <string>Gcircumflex</string>
-      <string>gcircumflex</string>
-      <string>Gbreve</string>
-      <string>gbreve</string>
       <string>uni0120</string>
       <string>uni0121</string>
-      <string>Gcommaaccent</string>
-      <string>gcommaaccent</string>
-      <string>Hcircumflex</string>
-      <string>hcircumflex</string>
-      <string>Itilde</string>
-      <string>itilde</string>
-      <string>Imacron</string>
-      <string>imacron</string>
-      <string>Ibreve</string>
-      <string>ibreve</string>
-      <string>Iogonek</string>
-      <string>iogonek</string>
-      <string>Idotaccent</string>
-      <string>Jcircumflex</string>
-      <string>jcircumflex</string>
-      <string>Kcommaaccent</string>
-      <string>kcommaaccent</string>
-      <string>Lacute</string>
-      <string>lacute</string>
-      <string>Lcommaaccent</string>
-      <string>lcommaaccent</string>
-      <string>Lcaron</string>
-      <string>lcaron</string>
-      <string>Ldot</string>
-      <string>ldot</string>
-      <string>Nacute</string>
-      <string>nacute</string>
-      <string>Ncommaaccent</string>
-      <string>ncommaaccent</string>
-      <string>Ncaron</string>
-      <string>ncaron</string>
       <string>napostrophe</string>
-      <string>Omacron</string>
-      <string>omacron</string>
-      <string>Obreve</string>
-      <string>obreve</string>
-      <string>Ohungarumlaut</string>
-      <string>ohungarumlaut</string>
-      <string>Racute</string>
-      <string>racute</string>
-      <string>Rcommaaccent</string>
-      <string>rcommaaccent</string>
-      <string>Rcaron</string>
-      <string>rcaron</string>
-      <string>Sacute</string>
-      <string>sacute</string>
-      <string>Scircumflex</string>
-      <string>scircumflex</string>
-      <string>Scedilla</string>
-      <string>scedilla</string>
       <string>uni0218</string>
       <string>uni0219</string>
-      <string>Scaron</string>
-      <string>scaron</string>
       <string>uni021A</string>
       <string>uni021B</string>
       <string>uni0162</string>
       <string>uni0162.smcp</string>
       <string>uni0163</string>
-      <string>Tcaron</string>
-      <string>tcaron</string>
-      <string>Utilde</string>
-      <string>utilde</string>
-      <string>Umacron</string>
-      <string>umacron</string>
-      <string>Ubreve</string>
-      <string>ubreve</string>
-      <string>Uring</string>
-      <string>uring</string>
-      <string>Uhungarumlaut</string>
-      <string>uhungarumlaut</string>
-      <string>Uogonek</string>
-      <string>uogonek</string>
-      <string>Wcircumflex</string>
-      <string>wcircumflex</string>
-      <string>Ycircumflex</string>
-      <string>ycircumflex</string>
-      <string>Ydieresis</string>
-      <string>Zacute</string>
-      <string>zacute</string>
-      <string>Zdotaccent</string>
-      <string>zdotaccent</string>
-      <string>Zcaron</string>
-      <string>zcaron</string>
-      <string>AEacute</string>
-      <string>aeacute</string>
-      <string>Oslashacute</string>
-      <string>oslashacute</string>
       <string>Dcroat.smcp</string>
       <string>Eth.smcp</string>
       <string>Tbar.smcp</string>
@@ -807,16 +831,6 @@
       <string>uni0458</string>
       <string>uni045C</string>
       <string>uni045E</string>
-      <string>Wgrave</string>
-      <string>wgrave</string>
-      <string>Wacute</string>
-      <string>wacute</string>
-      <string>Wdieresis</string>
-      <string>wdieresis</string>
-      <string>Ygrave</string>
-      <string>ygrave</string>
-      <string>minute</string>
-      <string>second</string>
       <string>exclamdbl</string>
       <string>uni01F0</string>
       <string>uni02BC</string>
@@ -973,7 +987,6 @@
       <string>uni1EF7</string>
       <string>uni1EF8</string>
       <string>uni1EF9</string>
-      <string>dcroat</string>
       <string>uni20AB</string>
       <string>uni049A</string>
       <string>uni049B</string>
@@ -1014,9 +1027,7 @@
       <string>uni04FE</string>
       <string>uni04FF</string>
       <string>uni0511</string>
-      <string>franc</string>
       <string>uni2015</string>
-      <string>exclam</string>
     </array>
   </dict>
 </plist>

--- a/sources/RobotoMono-ThinItalic.ufo/glyphs/D_croat.glif
+++ b/sources/RobotoMono-ThinItalic.ufo/glyphs/D_croat.glif
@@ -1,57 +1,57 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Dcroat" format="2">
-  <advance width="1232"/>
+  <advance width="1202"/>
   <unicode hex="0110"/>
   <outline>
     <contour>
-      <point x="119" y="0" type="line"/>
-      <point x="243" y="713" type="line"/>
-      <point x="-23" y="713" type="line"/>
-      <point x="-15" y="767" type="line"/>
-      <point x="252" y="767" type="line"/>
-      <point x="372" y="1456" type="line"/>
-      <point x="723" y="1456" type="line" smooth="yes"/>
-      <point x="807" y="1454"/>
-      <point x="941" y="1398"/>
-      <point x="992" y="1352" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="1043" y="1305"/>
-      <point x="1112" y="1181"/>
-      <point x="1131" y="1111" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="1150" y="1041"/>
-      <point x="1156" y="890"/>
-      <point x="1145" y="817" type="qcurve" smooth="yes"/>
-      <point x="1115" y="639" type="line" smooth="yes"/>
-      <point x="1092.9104279179558" y="517.507353548757"/>
-      <point x="976.3799379567175" y="281.11056101786494"/>
-      <point x="889" y="191" type="qcurve" smooth="yes"/>
-      <point x="810.5785983227581" y="109.31103991953962"/>
-      <point x="602.4852528073177" y="2.8820059484074756"/>
-      <point x="480" y="0" type="qcurve" smooth="yes"/>
+      <point x="104" y="0" type="line"/>
+      <point x="228" y="713" type="line"/>
+      <point x="-38" y="713" type="line"/>
+      <point x="-30" y="767" type="line"/>
+      <point x="237" y="767" type="line"/>
+      <point x="357" y="1456" type="line"/>
+      <point x="708" y="1456" type="line" smooth="yes"/>
+      <point x="792" y="1454"/>
+      <point x="926" y="1398"/>
+      <point x="977" y="1352" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="1028" y="1305"/>
+      <point x="1097" y="1181"/>
+      <point x="1116" y="1111" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="1135" y="1041"/>
+      <point x="1141" y="890"/>
+      <point x="1130" y="817" type="qcurve" smooth="yes"/>
+      <point x="1100" y="639" type="line" smooth="yes"/>
+      <point x="1078" y="518"/>
+      <point x="961" y="281"/>
+      <point x="874" y="191" type="qcurve" smooth="yes"/>
+      <point x="796" y="109"/>
+      <point x="587" y="3"/>
+      <point x="465" y="0" type="qcurve" smooth="yes"/>
     </contour>
     <contour>
-      <point x="548" y="713" type="line"/>
-      <point x="295" y="713" type="line"/>
-      <point x="181" y="54" type="line"/>
-      <point x="480" y="54" type="line" smooth="yes"/>
-      <point x="592.5753420079953" y="56.92403485735052"/>
-      <point x="784.2183282004152" y="156.88948717436438"/>
-      <point x="857" y="236" type="qcurve" smooth="yes"/>
-      <point x="933.5767984401718" y="318.2491538801847"/>
-      <point x="1038.375465703858" y="530.8773285192912"/>
-      <point x="1060" y="639" type="qcurve" smooth="yes"/>
-      <point x="1092" y="820" type="line" smooth="yes"/>
-      <point x="1102" y="885"/>
-      <point x="1098" y="1021"/>
-      <point x="1083" y="1085" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="1067" y="1149"/>
-      <point x="1008" y="1262"/>
-      <point x="964" y="1305" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="919" y="1348"/>
-      <point x="799" y="1400"/>
-      <point x="723" y="1402" type="qcurve" smooth="yes"/>
-      <point x="415" y="1402" type="line"/>
-      <point x="305" y="767" type="line"/>
-      <point x="556" y="767" type="line"/>
+      <point x="533" y="713" type="line"/>
+      <point x="280" y="713" type="line"/>
+      <point x="166" y="54" type="line"/>
+      <point x="465" y="54" type="line" smooth="yes"/>
+      <point x="578" y="57"/>
+      <point x="769" y="157"/>
+      <point x="842" y="236" type="qcurve" smooth="yes"/>
+      <point x="919" y="318"/>
+      <point x="1023" y="531"/>
+      <point x="1045" y="639" type="qcurve" smooth="yes"/>
+      <point x="1077" y="820" type="line" smooth="yes"/>
+      <point x="1087" y="885"/>
+      <point x="1083" y="1021"/>
+      <point x="1068" y="1085" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="1052" y="1149"/>
+      <point x="993" y="1262"/>
+      <point x="949" y="1305" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="904" y="1348"/>
+      <point x="784" y="1400"/>
+      <point x="708" y="1402" type="qcurve" smooth="yes"/>
+      <point x="400" y="1402" type="line"/>
+      <point x="290" y="767" type="line"/>
+      <point x="541" y="767" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/RobotoMono-ThinItalic.ufo/glyphs/E_psilontonos.glif
+++ b/sources/RobotoMono-ThinItalic.ufo/glyphs/E_psilontonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Epsilontonos" format="2">
-  <advance width="1302"/>
+  <advance width="1202"/>
   <unicode hex="0388"/>
   <outline>
-    <component base="E" xOffset="100"/>
-    <component base="tonos" xOffset="-497" yOffset="1"/>
+    <component base="E" xOffset="50"/>
+    <component base="tonos" xOffset="-547" yOffset="1"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-ThinItalic.ufo/glyphs/E_tatonos.glif
+++ b/sources/RobotoMono-ThinItalic.ufo/glyphs/E_tatonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Etatonos" format="2">
-  <advance width="1302"/>
+  <advance width="1202"/>
   <unicode hex="0389"/>
   <outline>
-    <component base="H" xOffset="100"/>
-    <component base="tonos" xOffset="-516" yOffset="1"/>
+    <component base="H" xOffset="50"/>
+    <component base="tonos" xOffset="-566" yOffset="1"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-ThinItalic.ufo/glyphs/E_th.glif
+++ b/sources/RobotoMono-ThinItalic.ufo/glyphs/E_th.glif
@@ -1,57 +1,57 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Eth" format="2">
-  <advance width="1232"/>
+  <advance width="1202"/>
   <unicode hex="00D0"/>
   <outline>
     <contour>
-      <point x="119" y="0" type="line"/>
-      <point x="243" y="713" type="line"/>
-      <point x="-23" y="713" type="line"/>
-      <point x="-15" y="767" type="line"/>
-      <point x="252" y="767" type="line"/>
-      <point x="372" y="1456" type="line"/>
-      <point x="723" y="1456" type="line" smooth="yes"/>
-      <point x="807" y="1454"/>
-      <point x="941" y="1398"/>
-      <point x="992" y="1352" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="1043" y="1305"/>
-      <point x="1112" y="1181"/>
-      <point x="1131" y="1111" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="1150" y="1041"/>
-      <point x="1156" y="890"/>
-      <point x="1145" y="817" type="qcurve" smooth="yes"/>
-      <point x="1115" y="639" type="line" smooth="yes"/>
-      <point x="1093" y="518"/>
-      <point x="976" y="281"/>
-      <point x="889" y="191" type="qcurve" smooth="yes"/>
-      <point x="811" y="109"/>
-      <point x="602" y="3"/>
-      <point x="480" y="0" type="qcurve" smooth="yes"/>
+      <point x="104" y="0" type="line"/>
+      <point x="228" y="713" type="line"/>
+      <point x="-38" y="713" type="line"/>
+      <point x="-30" y="767" type="line"/>
+      <point x="237" y="767" type="line"/>
+      <point x="357" y="1456" type="line"/>
+      <point x="708" y="1456" type="line" smooth="yes"/>
+      <point x="792" y="1454"/>
+      <point x="926" y="1398"/>
+      <point x="977" y="1352" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="1028" y="1305"/>
+      <point x="1097" y="1181"/>
+      <point x="1116" y="1111" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="1135" y="1041"/>
+      <point x="1141" y="890"/>
+      <point x="1130" y="817" type="qcurve" smooth="yes"/>
+      <point x="1100" y="639" type="line" smooth="yes"/>
+      <point x="1078" y="518"/>
+      <point x="961" y="281"/>
+      <point x="874" y="191" type="qcurve" smooth="yes"/>
+      <point x="796" y="109"/>
+      <point x="587" y="3"/>
+      <point x="465" y="0" type="qcurve" smooth="yes"/>
     </contour>
     <contour>
-      <point x="548" y="713" type="line"/>
-      <point x="295" y="713" type="line"/>
-      <point x="181" y="54" type="line"/>
-      <point x="480" y="54" type="line" smooth="yes"/>
-      <point x="593" y="57"/>
-      <point x="784" y="157"/>
-      <point x="857" y="236" type="qcurve" smooth="yes"/>
-      <point x="934" y="318"/>
-      <point x="1038" y="531"/>
-      <point x="1060" y="639" type="qcurve" smooth="yes"/>
-      <point x="1092" y="820" type="line" smooth="yes"/>
-      <point x="1102" y="885"/>
-      <point x="1098" y="1021"/>
-      <point x="1083" y="1085" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="1067" y="1149"/>
-      <point x="1008" y="1262"/>
-      <point x="964" y="1305" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="919" y="1348"/>
-      <point x="799" y="1400"/>
-      <point x="723" y="1402" type="qcurve" smooth="yes"/>
-      <point x="415" y="1402" type="line"/>
-      <point x="305" y="767" type="line"/>
-      <point x="556" y="767" type="line"/>
+      <point x="533" y="713" type="line"/>
+      <point x="280" y="713" type="line"/>
+      <point x="166" y="54" type="line"/>
+      <point x="465" y="54" type="line" smooth="yes"/>
+      <point x="578" y="57"/>
+      <point x="769" y="157"/>
+      <point x="842" y="236" type="qcurve" smooth="yes"/>
+      <point x="919" y="318"/>
+      <point x="1023" y="531"/>
+      <point x="1045" y="639" type="qcurve" smooth="yes"/>
+      <point x="1077" y="820" type="line" smooth="yes"/>
+      <point x="1087" y="885"/>
+      <point x="1083" y="1021"/>
+      <point x="1068" y="1085" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="1052" y="1149"/>
+      <point x="993" y="1262"/>
+      <point x="949" y="1305" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="904" y="1348"/>
+      <point x="784" y="1400"/>
+      <point x="708" y="1402" type="qcurve" smooth="yes"/>
+      <point x="400" y="1402" type="line"/>
+      <point x="290" y="767" type="line"/>
+      <point x="541" y="767" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/RobotoMono-ThinItalic.ufo/glyphs/I_otatonos.glif
+++ b/sources/RobotoMono-ThinItalic.ufo/glyphs/I_otatonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Iotatonos" format="2">
-  <advance width="1302"/>
+  <advance width="1202"/>
   <unicode hex="038A"/>
   <outline>
-    <component base="I" xOffset="100"/>
-    <component base="tonos" xOffset="-531" yOffset="1"/>
+    <component base="I" xOffset="50"/>
+    <component base="tonos" xOffset="-581" yOffset="1"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-ThinItalic.ufo/glyphs/O_megatonos.glif
+++ b/sources/RobotoMono-ThinItalic.ufo/glyphs/O_megatonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omegatonos" format="2">
-  <advance width="1222"/>
+  <advance width="1202"/>
   <unicode hex="038F"/>
   <outline>
-    <component base="Omega" xOffset="20"/>
-    <component base="tonos" xOffset="-548" yOffset="-1"/>
+    <component base="Omega" xOffset="10"/>
+    <component base="tonos" xOffset="-558" yOffset="-1"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-ThinItalic.ufo/glyphs/O_microntonos.glif
+++ b/sources/RobotoMono-ThinItalic.ufo/glyphs/O_microntonos.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Omicrontonos" format="2">
-  <advance width="1222"/>
+  <advance width="1202"/>
   <unicode hex="038C"/>
   <outline>
     <component base="O" xOffset="20"/>

--- a/sources/RobotoMono-ThinItalic.ufo/glyphs/U_psilontonos.glif
+++ b/sources/RobotoMono-ThinItalic.ufo/glyphs/U_psilontonos.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Upsilontonos" format="2">
-  <advance width="1302"/>
+  <advance width="1202"/>
   <unicode hex="038E"/>
   <outline>
-    <component base="Y" xOffset="100"/>
-    <component base="tonos" xOffset="-598" yOffset="-1"/>
+    <component base="Y" xOffset="50"/>
+    <component base="tonos" xOffset="-648" yOffset="-1"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-ThinItalic.ufo/glyphs/acutecomb.glif
+++ b/sources/RobotoMono-ThinItalic.ufo/glyphs/acutecomb.glif
@@ -1,6 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="acutecomb" format="2">
-  <advance width="10"/>
   <unicode hex="0301"/>
   <outline>
     <contour>

--- a/sources/RobotoMono-ThinItalic.ufo/glyphs/contents.plist
+++ b/sources/RobotoMono-ThinItalic.ufo/glyphs/contents.plist
@@ -1140,6 +1140,10 @@
     <string>underscore.glif</string>
     <key>underscoredbl</key>
     <string>underscoredbl.glif</string>
+    <key>uni0002</key>
+    <string>uni0002.glif</string>
+    <key>uni0009</key>
+    <string>uni0009.glif</string>
     <key>uni00AD</key>
     <string>uni00A_D_.glif</string>
     <key>uni010A</key>

--- a/sources/RobotoMono-ThinItalic.ufo/glyphs/dcaron.glif
+++ b/sources/RobotoMono-ThinItalic.ufo/glyphs/dcaron.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="dcaron" format="2">
-  <advance width="1352"/>
+  <advance width="1202"/>
   <unicode hex="010F"/>
   <outline>
-    <component base="d"/>
-    <component base="quoteright" xOffset="648"/>
+    <component base="d" xOffset="-70"/>
+    <component base="quoteright" xOffset="578"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-ThinItalic.ufo/glyphs/dcroat.glif
+++ b/sources/RobotoMono-ThinItalic.ufo/glyphs/dcroat.glif
@@ -1,84 +1,84 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="dcroat" format="2">
-  <advance width="1232"/>
+  <advance width="1202"/>
   <unicode hex="0111"/>
   <outline>
     <contour>
-      <point x="1273" y="1281" type="line"/>
-      <point x="1093" y="1281" type="line"/>
-      <point x="873" y="0" type="line"/>
-      <point x="819" y="0" type="line"/>
-      <point x="850" y="162" type="line"/>
-      <point x="816" y="122"/>
-      <point x="733" y="55"/>
-      <point x="685.5" y="31.0" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="638" y="7"/>
-      <point x="536" y="-20"/>
-      <point x="482" y="-20" type="qcurve" smooth="yes"/>
-      <point x="407" y="-20"/>
-      <point x="296" y="28"/>
-      <point x="257.0" y="69.5" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="218" y="111"/>
-      <point x="170" y="220"/>
-      <point x="159.0" y="281.5" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="148" y="343"/>
-      <point x="149" y="471"/>
-      <point x="158" y="531" type="qcurve" smooth="yes"/>
-      <point x="162" y="552" type="line" smooth="yes"/>
-      <point x="173" y="617"/>
-      <point x="216" y="749"/>
-      <point x="247.5" y="810.0" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="279" y="871"/>
-      <point x="362" y="978"/>
-      <point x="414.5" y="1017.5" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="467" y="1057"/>
-      <point x="593" y="1102"/>
-      <point x="668" y="1102" type="qcurve" smooth="yes"/>
-      <point x="719" y="1102"/>
-      <point x="812" y="1072"/>
-      <point x="851.0" y="1045.0" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="890" y="1018"/>
-      <point x="951" y="942"/>
-      <point x="971" y="896" type="qcurve"/>
-      <point x="1038" y="1281" type="line"/>
-      <point x="702" y="1281" type="line"/>
-      <point x="710" y="1335" type="line"/>
-      <point x="1048" y="1335" type="line"/>
-      <point x="1083" y="1536" type="line"/>
-      <point x="1137" y="1536" type="line"/>
-      <point x="1102" y="1335" type="line"/>
-      <point x="1281" y="1335" type="line"/>
+      <point x="1258" y="1281" type="line"/>
+      <point x="1078" y="1281" type="line"/>
+      <point x="858" y="0" type="line"/>
+      <point x="804" y="0" type="line"/>
+      <point x="835" y="162" type="line"/>
+      <point x="801" y="122"/>
+      <point x="718" y="55"/>
+      <point x="671" y="31.0" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="623" y="7"/>
+      <point x="521" y="-20"/>
+      <point x="467" y="-20" type="qcurve" smooth="yes"/>
+      <point x="392" y="-20"/>
+      <point x="281" y="28"/>
+      <point x="242.0" y="70" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="203" y="111"/>
+      <point x="155" y="220"/>
+      <point x="144.0" y="282" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="133" y="343"/>
+      <point x="134" y="471"/>
+      <point x="143" y="531" type="qcurve" smooth="yes"/>
+      <point x="147" y="552" type="line" smooth="yes"/>
+      <point x="158" y="617"/>
+      <point x="201" y="749"/>
+      <point x="233" y="810.0" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="264" y="871"/>
+      <point x="347" y="978"/>
+      <point x="400" y="1018" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="452" y="1057"/>
+      <point x="578" y="1102"/>
+      <point x="653" y="1102" type="qcurve" smooth="yes"/>
+      <point x="704" y="1102"/>
+      <point x="797" y="1072"/>
+      <point x="836.0" y="1045.0" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="875" y="1018"/>
+      <point x="936" y="942"/>
+      <point x="956" y="896" type="qcurve"/>
+      <point x="1023" y="1281" type="line"/>
+      <point x="687" y="1281" type="line"/>
+      <point x="695" y="1335" type="line"/>
+      <point x="1033" y="1335" type="line"/>
+      <point x="1068" y="1536" type="line"/>
+      <point x="1122" y="1536" type="line"/>
+      <point x="1087" y="1335" type="line"/>
+      <point x="1266" y="1335" type="line"/>
     </contour>
     <contour>
-      <point x="214" y="531" type="line" smooth="yes"/>
-      <point x="205" y="479"/>
-      <point x="200" y="365"/>
-      <point x="207.5" y="310.0" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="215" y="255"/>
-      <point x="251" y="156"/>
-      <point x="283.5" y="118.0" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="316" y="80"/>
-      <point x="413" y="35"/>
-      <point x="480" y="34" type="qcurve" smooth="yes"/>
-      <point x="538" y="34"/>
-      <point x="649" y="66"/>
-      <point x="698.5" y="95.5" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="748" y="125"/>
-      <point x="831" y="206"/>
-      <point x="861" y="255" type="qcurve"/>
-      <point x="956" y="790" type="line"/>
-      <point x="947" y="845"/>
-      <point x="898" y="940"/>
-      <point x="860.5" y="974.5" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="823" y="1009"/>
-      <point x="726" y="1048"/>
-      <point x="668" y="1048" type="qcurve" smooth="yes"/>
-      <point x="568" y="1048"/>
-      <point x="415" y="958"/>
-      <point x="359.5" y="886.5" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="304" y="815"/>
-      <point x="234" y="638"/>
-      <point x="218" y="552" type="qcurve" smooth="yes"/>
+      <point x="199" y="531" type="line" smooth="yes"/>
+      <point x="190" y="479"/>
+      <point x="185" y="365"/>
+      <point x="193" y="310.0" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="200" y="255"/>
+      <point x="236" y="156"/>
+      <point x="269" y="118.0" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="301" y="80"/>
+      <point x="398" y="35"/>
+      <point x="465" y="34" type="qcurve" smooth="yes"/>
+      <point x="523" y="34"/>
+      <point x="634" y="66"/>
+      <point x="684" y="96" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="733" y="125"/>
+      <point x="816" y="206"/>
+      <point x="846" y="255" type="qcurve"/>
+      <point x="941" y="790" type="line"/>
+      <point x="932" y="845"/>
+      <point x="883" y="940"/>
+      <point x="846" y="975" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="808" y="1009"/>
+      <point x="711" y="1048"/>
+      <point x="653" y="1048" type="qcurve" smooth="yes"/>
+      <point x="553" y="1048"/>
+      <point x="400" y="958"/>
+      <point x="345" y="887" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="289" y="815"/>
+      <point x="219" y="638"/>
+      <point x="203" y="552" type="qcurve" smooth="yes"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/RobotoMono-ThinItalic.ufo/glyphs/dotbelow.glif
+++ b/sources/RobotoMono-ThinItalic.ufo/glyphs/dotbelow.glif
@@ -1,6 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="dotbelow" format="2">
-  <advance width="10"/>
   <unicode hex="0323"/>
   <outline>
     <contour>

--- a/sources/RobotoMono-ThinItalic.ufo/glyphs/exclamdbl.glif
+++ b/sources/RobotoMono-ThinItalic.ufo/glyphs/exclamdbl.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="exclamdbl" format="2">
-  <advance width="2404"/>
+  <advance width="1202"/>
   <unicode hex="203C"/>
   <outline>
     <component base="exclam"/>
-    <component base="exclam" xOffset="1202"/>
+    <component base="exclam" xOffset="743" yOffset="-16"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-ThinItalic.ufo/glyphs/f.glif
+++ b/sources/RobotoMono-ThinItalic.ufo/glyphs/f.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="f" format="2">
-  <advance width="1203"/>
+  <advance width="1202"/>
   <unicode hex="0066"/>
   <outline>
     <contour>

--- a/sources/RobotoMono-ThinItalic.ufo/glyphs/gravecomb.glif
+++ b/sources/RobotoMono-ThinItalic.ufo/glyphs/gravecomb.glif
@@ -1,6 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="gravecomb" format="2">
-  <advance width="10"/>
   <unicode hex="0300"/>
   <outline>
     <contour>

--- a/sources/RobotoMono-ThinItalic.ufo/glyphs/hbar.glif
+++ b/sources/RobotoMono-ThinItalic.ufo/glyphs/hbar.glif
@@ -1,49 +1,49 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="hbar" format="2">
-  <advance width="1232"/>
+  <advance width="1202"/>
   <unicode hex="0127"/>
   <outline>
     <contour>
-      <point x="710" y="1281" type="line"/>
-      <point x="407" y="1281" type="line"/>
-      <point x="325" y="821" type="line"/>
-      <point x="361" y="879"/>
-      <point x="454" y="981"/>
-      <point x="509.5" y="1019.0" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="565" y="1057"/>
-      <point x="693" y="1102"/>
-      <point x="764" y="1102" type="qcurve" smooth="yes"/>
-      <point x="853" y="1102"/>
-      <point x="974" y="1036"/>
-      <point x="1008.5" y="980.5" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="1043" y="925"/>
-      <point x="1062" y="779"/>
-      <point x="1050" y="700" type="qcurve" smooth="yes"/>
-      <point x="930" y="0" type="line"/>
-      <point x="875" y="0" type="line"/>
-      <point x="996" y="700" type="line" smooth="yes"/>
-      <point x="1007" y="767"/>
-      <point x="996" y="894"/>
-      <point x="969.0" y="942.5" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="942" y="991"/>
-      <point x="841" y="1050"/>
-      <point x="762" y="1049" type="qcurve" smooth="yes"/>
-      <point x="691" y="1048"/>
-      <point x="548" y="991"/>
-      <point x="485.5" y="943.0" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="423" y="895"/>
-      <point x="330" y="770"/>
-      <point x="309" y="702" type="qcurve"/>
-      <point x="188" y="0" type="line"/>
-      <point x="133" y="0" type="line"/>
-      <point x="354" y="1281" type="line"/>
-      <point x="139" y="1281" type="line"/>
-      <point x="147" y="1335" type="line"/>
-      <point x="363" y="1335" type="line"/>
-      <point x="398" y="1536" type="line"/>
-      <point x="452" y="1536" type="line"/>
-      <point x="416" y="1335" type="line"/>
-      <point x="718" y="1335" type="line"/>
+      <point x="695" y="1281" type="line"/>
+      <point x="392" y="1281" type="line"/>
+      <point x="310" y="821" type="line"/>
+      <point x="346" y="879"/>
+      <point x="439" y="981"/>
+      <point x="495" y="1019.0" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="550" y="1057"/>
+      <point x="678" y="1102"/>
+      <point x="749" y="1102" type="qcurve" smooth="yes"/>
+      <point x="838" y="1102"/>
+      <point x="959" y="1036"/>
+      <point x="994" y="981" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="1028" y="925"/>
+      <point x="1047" y="779"/>
+      <point x="1035" y="700" type="qcurve" smooth="yes"/>
+      <point x="915" y="0" type="line"/>
+      <point x="860" y="0" type="line"/>
+      <point x="981" y="700" type="line" smooth="yes"/>
+      <point x="992" y="767"/>
+      <point x="981" y="894"/>
+      <point x="954.0" y="943" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="927" y="991"/>
+      <point x="826" y="1050"/>
+      <point x="747" y="1049" type="qcurve" smooth="yes"/>
+      <point x="676" y="1048"/>
+      <point x="533" y="991"/>
+      <point x="471" y="943.0" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="408" y="895"/>
+      <point x="315" y="770"/>
+      <point x="294" y="702" type="qcurve"/>
+      <point x="173" y="0" type="line"/>
+      <point x="118" y="0" type="line"/>
+      <point x="339" y="1281" type="line"/>
+      <point x="124" y="1281" type="line"/>
+      <point x="132" y="1335" type="line"/>
+      <point x="348" y="1335" type="line"/>
+      <point x="383" y="1536" type="line"/>
+      <point x="437" y="1536" type="line"/>
+      <point x="401" y="1335" type="line"/>
+      <point x="703" y="1335" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/RobotoMono-ThinItalic.ufo/glyphs/hook.glif
+++ b/sources/RobotoMono-ThinItalic.ufo/glyphs/hook.glif
@@ -1,6 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="hook" format="2">
-  <advance width="10"/>
   <unicode hex="0309"/>
   <outline>
     <contour>

--- a/sources/RobotoMono-ThinItalic.ufo/glyphs/hyphen.glif
+++ b/sources/RobotoMono-ThinItalic.ufo/glyphs/hyphen.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="hyphen" format="2">
-  <advance width="1203"/>
+  <advance width="1202"/>
   <unicode hex="002D"/>
   <outline>
     <contour>

--- a/sources/RobotoMono-ThinItalic.ufo/glyphs/lcaron.glif
+++ b/sources/RobotoMono-ThinItalic.ufo/glyphs/lcaron.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="lcaron" format="2">
-  <advance width="1352"/>
+  <advance width="1202"/>
   <unicode hex="013E"/>
   <outline>
-    <component base="l"/>
-    <component base="quoteright" xOffset="381" yOffset="2"/>
+    <component base="l" xOffset="-70"/>
+    <component base="quoteright" xOffset="311" yOffset="2"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-ThinItalic.ufo/glyphs/ldot.glif
+++ b/sources/RobotoMono-ThinItalic.ufo/glyphs/ldot.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ldot" format="2">
-  <advance width="1422"/>
+  <advance width="1202"/>
   <unicode hex="0140"/>
   <outline>
-    <component base="l"/>
-    <component base="dotaccent" xOffset="183" yOffset="-571"/>
+    <component base="l" xOffset="-70"/>
+    <component base="dotaccent" xOffset="113" yOffset="-571"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-ThinItalic.ufo/glyphs/tcaron.glif
+++ b/sources/RobotoMono-ThinItalic.ufo/glyphs/tcaron.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="tcaron" format="2">
-  <advance width="1242"/>
+  <advance width="1202"/>
   <unicode hex="0165"/>
   <outline>
-    <component base="t"/>
-    <component base="quoteright" xOffset="312" yOffset="23"/>
+    <component base="t" xOffset="-15"/>
+    <component base="quoteright" xOffset="297" yOffset="23"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-ThinItalic.ufo/glyphs/tildecomb.glif
+++ b/sources/RobotoMono-ThinItalic.ufo/glyphs/tildecomb.glif
@@ -1,6 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="tildecomb" format="2">
-  <advance width="10"/>
   <unicode hex="0303"/>
   <outline>
     <component base="tilde" xOffset="-1057"/>

--- a/sources/RobotoMono-ThinItalic.ufo/glyphs/uni0002.glif
+++ b/sources/RobotoMono-ThinItalic.ufo/glyphs/uni0002.glif
@@ -1,0 +1,7 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni0002" format="2">
+  <advance width="1202"/>
+  <unicode hex="0002"/>
+  <outline>
+  </outline>
+</glyph>

--- a/sources/RobotoMono-ThinItalic.ufo/glyphs/uni0009.glif
+++ b/sources/RobotoMono-ThinItalic.ufo/glyphs/uni0009.glif
@@ -1,0 +1,7 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni0009" format="2">
+  <advance width="1202"/>
+  <unicode hex="0009"/>
+  <outline>
+  </outline>
+</glyph>

--- a/sources/RobotoMono-ThinItalic.ufo/glyphs/uni00A_D_.glif
+++ b/sources/RobotoMono-ThinItalic.ufo/glyphs/uni00A_D_.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni00AD" format="2">
-  <advance width="1203"/>
+  <advance width="1202"/>
   <unicode hex="00AD"/>
   <outline>
     <component base="hyphen"/>

--- a/sources/RobotoMono-ThinItalic.ufo/glyphs/uni030F_.glif
+++ b/sources/RobotoMono-ThinItalic.ufo/glyphs/uni030F_.glif
@@ -1,6 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni030F" format="2">
-  <advance width="10"/>
   <unicode hex="030F"/>
   <outline>
     <contour>

--- a/sources/RobotoMono-ThinItalic.ufo/glyphs/uni0483.glif
+++ b/sources/RobotoMono-ThinItalic.ufo/glyphs/uni0483.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni0483" format="2">
-  <advance width="10"/>
+  <advance width="1202"/>
   <unicode hex="0483"/>
   <outline>
     <contour>

--- a/sources/RobotoMono-ThinItalic.ufo/glyphs/uni0484.glif
+++ b/sources/RobotoMono-ThinItalic.ufo/glyphs/uni0484.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni0484" format="2">
-  <advance width="10"/>
+  <advance width="1202"/>
   <unicode hex="0484"/>
   <outline>
     <contour>

--- a/sources/RobotoMono-ThinItalic.ufo/glyphs/uni0485.glif
+++ b/sources/RobotoMono-ThinItalic.ufo/glyphs/uni0485.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni0485" format="2">
-  <advance width="10"/>
+  <advance width="1202"/>
   <unicode hex="0485"/>
   <outline>
     <contour>

--- a/sources/RobotoMono-ThinItalic.ufo/glyphs/uni0486.glif
+++ b/sources/RobotoMono-ThinItalic.ufo/glyphs/uni0486.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni0486" format="2">
-  <advance width="10"/>
+  <advance width="1202"/>
   <unicode hex="0486"/>
   <outline>
     <contour>

--- a/sources/RobotoMono-ThinItalic.ufo/glyphs/uni0488.glif
+++ b/sources/RobotoMono-ThinItalic.ufo/glyphs/uni0488.glif
@@ -1,231 +1,231 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni0488" format="2">
-  <advance width="10"/>
+  <advance width="1202"/>
   <unicode hex="0488"/>
   <outline>
     <contour>
-      <point x="570" y="1268" type="line"/>
-      <point x="581" y="1309"/>
-      <point x="622" y="1377"/>
-      <point x="651" y="1401" type="qcurve" smooth="yes"/>
-      <point x="680" y="1426"/>
-      <point x="756" y="1454"/>
-      <point x="801" y="1455" type="qcurve" smooth="yes"/>
-      <point x="845" y="1455"/>
-      <point x="913" y="1427"/>
-      <point x="936" y="1403" type="qcurve" smooth="yes"/>
-      <point x="958" y="1378"/>
-      <point x="981" y="1309"/>
-      <point x="980" y="1267" type="qcurve"/>
-      <point x="871" y="1267" type="line"/>
-      <point x="871" y="1286"/>
-      <point x="865" y="1323"/>
-      <point x="857" y="1337" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="848" y="1350"/>
-      <point x="819" y="1367"/>
-      <point x="796" y="1367" type="qcurve" smooth="yes"/>
-      <point x="772" y="1367"/>
-      <point x="736" y="1351"/>
-      <point x="723" y="1337" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="709" y="1323"/>
-      <point x="689" y="1287"/>
-      <point x="682" y="1267" type="qcurve"/>
+      <point x="467" y="1268" type="line"/>
+      <point x="478" y="1309"/>
+      <point x="519" y="1377"/>
+      <point x="548" y="1401" type="qcurve" smooth="yes"/>
+      <point x="577" y="1426"/>
+      <point x="653" y="1454"/>
+      <point x="698" y="1455" type="qcurve" smooth="yes"/>
+      <point x="742" y="1455"/>
+      <point x="810" y="1427"/>
+      <point x="833" y="1403" type="qcurve" smooth="yes"/>
+      <point x="855" y="1378"/>
+      <point x="878" y="1309"/>
+      <point x="877" y="1267" type="qcurve"/>
+      <point x="768" y="1267" type="line"/>
+      <point x="768" y="1286"/>
+      <point x="762" y="1323"/>
+      <point x="754" y="1337" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="745" y="1350"/>
+      <point x="716" y="1367"/>
+      <point x="693" y="1367" type="qcurve" smooth="yes"/>
+      <point x="669" y="1367"/>
+      <point x="633" y="1351"/>
+      <point x="620" y="1337" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="606" y="1323"/>
+      <point x="586" y="1287"/>
+      <point x="579" y="1267" type="qcurve"/>
     </contour>
     <contour>
-      <point x="1095" y="991" type="line"/>
-      <point x="1107" y="1032"/>
-      <point x="1149" y="1100"/>
-      <point x="1178.5" y="1125.0" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="1208" y="1150"/>
-      <point x="1283" y="1178"/>
-      <point x="1327" y="1178" type="qcurve" smooth="yes"/>
-      <point x="1370" y="1178"/>
-      <point x="1438" y="1151"/>
-      <point x="1461.0" y="1126.0" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="1484" y="1101"/>
-      <point x="1507" y="1032"/>
-      <point x="1506" y="990" type="qcurve"/>
-      <point x="1397" y="990" type="line"/>
-      <point x="1397" y="1010"/>
-      <point x="1391" y="1046"/>
-      <point x="1382.5" y="1060.0" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="1374" y="1074"/>
-      <point x="1344" y="1090"/>
-      <point x="1321" y="1090" type="qcurve" smooth="yes"/>
-      <point x="1298" y="1090"/>
-      <point x="1262" y="1074"/>
-      <point x="1248.5" y="1060.0" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="1235" y="1046"/>
-      <point x="1215" y="1009"/>
-      <point x="1208" y="990" type="qcurve"/>
+      <point x="992" y="991" type="line"/>
+      <point x="1004" y="1032"/>
+      <point x="1046" y="1100"/>
+      <point x="1075.5" y="1125.0" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="1105" y="1150"/>
+      <point x="1180" y="1178"/>
+      <point x="1224" y="1178" type="qcurve" smooth="yes"/>
+      <point x="1267" y="1178"/>
+      <point x="1335" y="1151"/>
+      <point x="1358.0" y="1126.0" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="1381" y="1101"/>
+      <point x="1404" y="1032"/>
+      <point x="1403" y="990" type="qcurve"/>
+      <point x="1294" y="990" type="line"/>
+      <point x="1294" y="1010"/>
+      <point x="1288" y="1046"/>
+      <point x="1279.5" y="1060.0" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="1271" y="1074"/>
+      <point x="1241" y="1090"/>
+      <point x="1218" y="1090" type="qcurve" smooth="yes"/>
+      <point x="1195" y="1090"/>
+      <point x="1159" y="1074"/>
+      <point x="1145.5" y="1060.0" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="1132" y="1046"/>
+      <point x="1112" y="1009"/>
+      <point x="1105" y="990" type="qcurve"/>
     </contour>
     <contour>
-      <point x="1189" y="488" type="line"/>
-      <point x="1201" y="529"/>
-      <point x="1243" y="597"/>
-      <point x="1273" y="622" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="1302" y="647"/>
-      <point x="1377" y="675"/>
-      <point x="1421" y="675" type="qcurve" smooth="yes"/>
-      <point x="1464" y="675"/>
-      <point x="1531" y="648"/>
-      <point x="1554" y="624" type="qcurve" smooth="yes"/>
-      <point x="1577" y="599"/>
-      <point x="1600" y="529"/>
-      <point x="1599" y="487" type="qcurve"/>
-      <point x="1491" y="487" type="line"/>
-      <point x="1491" y="507"/>
-      <point x="1485" y="543"/>
-      <point x="1477" y="557" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="1468" y="571"/>
-      <point x="1439" y="587"/>
-      <point x="1416" y="587" type="qcurve" smooth="yes"/>
-      <point x="1392" y="587"/>
-      <point x="1356" y="571"/>
-      <point x="1343" y="557" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="1329" y="543"/>
-      <point x="1309" y="507"/>
-      <point x="1302" y="487" type="qcurve"/>
+      <point x="1086" y="488" type="line"/>
+      <point x="1098" y="529"/>
+      <point x="1140" y="597"/>
+      <point x="1170" y="622" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="1199" y="647"/>
+      <point x="1274" y="675"/>
+      <point x="1318" y="675" type="qcurve" smooth="yes"/>
+      <point x="1361" y="675"/>
+      <point x="1428" y="648"/>
+      <point x="1451" y="624" type="qcurve" smooth="yes"/>
+      <point x="1474" y="599"/>
+      <point x="1497" y="529"/>
+      <point x="1496" y="487" type="qcurve"/>
+      <point x="1388" y="487" type="line"/>
+      <point x="1388" y="507"/>
+      <point x="1382" y="543"/>
+      <point x="1374" y="557" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="1365" y="571"/>
+      <point x="1336" y="587"/>
+      <point x="1313" y="587" type="qcurve" smooth="yes"/>
+      <point x="1289" y="587"/>
+      <point x="1253" y="571"/>
+      <point x="1240" y="557" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="1226" y="543"/>
+      <point x="1206" y="507"/>
+      <point x="1199" y="487" type="qcurve"/>
     </contour>
     <contour>
-      <point x="908" y="-31" type="line"/>
-      <point x="920" y="10"/>
-      <point x="962" y="78"/>
-      <point x="992" y="103" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="1021" y="128"/>
-      <point x="1096" y="156"/>
-      <point x="1140" y="156" type="qcurve" smooth="yes"/>
-      <point x="1184" y="156"/>
-      <point x="1253" y="128"/>
-      <point x="1275" y="102" type="qcurve" smooth="yes"/>
-      <point x="1297" y="78"/>
-      <point x="1319" y="9"/>
-      <point x="1318" y="-32" type="qcurve"/>
-      <point x="1210" y="-32" type="line"/>
-      <point x="1210" y="-12"/>
-      <point x="1204" y="24"/>
-      <point x="1196" y="38" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="1187" y="52"/>
-      <point x="1158" y="68"/>
-      <point x="1135" y="68" type="qcurve" smooth="yes"/>
-      <point x="1111" y="68"/>
-      <point x="1075" y="52"/>
-      <point x="1062" y="38" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="1048" y="24"/>
-      <point x="1028" y="-12"/>
-      <point x="1021" y="-32" type="qcurve"/>
+      <point x="805" y="-31" type="line"/>
+      <point x="817" y="10"/>
+      <point x="859" y="78"/>
+      <point x="889" y="103" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="918" y="128"/>
+      <point x="993" y="156"/>
+      <point x="1037" y="156" type="qcurve" smooth="yes"/>
+      <point x="1081" y="156"/>
+      <point x="1150" y="128"/>
+      <point x="1172" y="102" type="qcurve" smooth="yes"/>
+      <point x="1194" y="78"/>
+      <point x="1216" y="9"/>
+      <point x="1215" y="-32" type="qcurve"/>
+      <point x="1107" y="-32" type="line"/>
+      <point x="1107" y="-12"/>
+      <point x="1101" y="24"/>
+      <point x="1093" y="38" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="1084" y="52"/>
+      <point x="1055" y="68"/>
+      <point x="1032" y="68" type="qcurve" smooth="yes"/>
+      <point x="1008" y="68"/>
+      <point x="972" y="52"/>
+      <point x="959" y="38" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="945" y="24"/>
+      <point x="925" y="-12"/>
+      <point x="918" y="-32" type="qcurve"/>
     </contour>
     <contour>
-      <point x="300" y="-315" type="line"/>
-      <point x="312" y="-273"/>
-      <point x="354" y="-204"/>
-      <point x="384" y="-179" type="qcurve" smooth="yes"/>
-      <point x="413" y="-155"/>
-      <point x="488" y="-128"/>
-      <point x="532" y="-128" type="qcurve" smooth="yes"/>
-      <point x="575" y="-128"/>
-      <point x="642" y="-155"/>
-      <point x="665" y="-180" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="688" y="-205"/>
-      <point x="712" y="-274"/>
-      <point x="711" y="-316" type="qcurve"/>
-      <point x="602" y="-316" type="line"/>
-      <point x="602" y="-297"/>
-      <point x="596" y="-260"/>
-      <point x="588" y="-246" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="579" y="-233"/>
-      <point x="550" y="-216"/>
-      <point x="527" y="-216" type="qcurve" smooth="yes"/>
-      <point x="503" y="-216"/>
-      <point x="467" y="-232"/>
-      <point x="454" y="-246" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="440" y="-260"/>
-      <point x="420" y="-296"/>
-      <point x="413" y="-316" type="qcurve"/>
+      <point x="197" y="-315" type="line"/>
+      <point x="209" y="-273"/>
+      <point x="251" y="-204"/>
+      <point x="281" y="-179" type="qcurve" smooth="yes"/>
+      <point x="310" y="-155"/>
+      <point x="385" y="-128"/>
+      <point x="429" y="-128" type="qcurve" smooth="yes"/>
+      <point x="472" y="-128"/>
+      <point x="539" y="-155"/>
+      <point x="562" y="-180" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="585" y="-205"/>
+      <point x="609" y="-274"/>
+      <point x="608" y="-316" type="qcurve"/>
+      <point x="499" y="-316" type="line"/>
+      <point x="499" y="-297"/>
+      <point x="493" y="-260"/>
+      <point x="485" y="-246" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="476" y="-233"/>
+      <point x="447" y="-216"/>
+      <point x="424" y="-216" type="qcurve" smooth="yes"/>
+      <point x="400" y="-216"/>
+      <point x="364" y="-232"/>
+      <point x="351" y="-246" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="337" y="-260"/>
+      <point x="317" y="-296"/>
+      <point x="310" y="-316" type="qcurve"/>
     </contour>
     <contour>
-      <point x="-34" y="991" type="line"/>
-      <point x="-22" y="1035"/>
-      <point x="25" y="1107"/>
-      <point x="57" y="1132" type="qcurve" smooth="yes"/>
-      <point x="86" y="1153"/>
-      <point x="157" y="1178"/>
-      <point x="198" y="1178" type="qcurve" smooth="yes"/>
-      <point x="242" y="1178"/>
-      <point x="311" y="1150"/>
-      <point x="334" y="1124" type="qcurve" smooth="yes"/>
-      <point x="356" y="1100"/>
-      <point x="378" y="1031"/>
-      <point x="377" y="990" type="qcurve"/>
-      <point x="269" y="990" type="line"/>
-      <point x="269" y="1009"/>
-      <point x="262" y="1046"/>
-      <point x="254" y="1060" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="246" y="1073"/>
-      <point x="216" y="1090"/>
-      <point x="193" y="1090" type="qcurve" smooth="yes"/>
-      <point x="170" y="1090"/>
-      <point x="134" y="1074"/>
-      <point x="121" y="1060" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="107" y="1046"/>
-      <point x="86" y="1010"/>
-      <point x="79" y="990" type="qcurve"/>
+      <point x="-137" y="991" type="line"/>
+      <point x="-125" y="1035"/>
+      <point x="-78" y="1107"/>
+      <point x="-46" y="1132" type="qcurve" smooth="yes"/>
+      <point x="-17" y="1153"/>
+      <point x="54" y="1178"/>
+      <point x="95" y="1178" type="qcurve" smooth="yes"/>
+      <point x="139" y="1178"/>
+      <point x="208" y="1150"/>
+      <point x="231" y="1124" type="qcurve" smooth="yes"/>
+      <point x="253" y="1100"/>
+      <point x="275" y="1031"/>
+      <point x="274" y="990" type="qcurve"/>
+      <point x="166" y="990" type="line"/>
+      <point x="166" y="1009"/>
+      <point x="159" y="1046"/>
+      <point x="151" y="1060" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="143" y="1073"/>
+      <point x="113" y="1090"/>
+      <point x="90" y="1090" type="qcurve" smooth="yes"/>
+      <point x="67" y="1090"/>
+      <point x="31" y="1074"/>
+      <point x="18" y="1060" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="4" y="1046"/>
+      <point x="-17" y="1010"/>
+      <point x="-24" y="990" type="qcurve"/>
     </contour>
     <contour>
-      <point x="-292" y="488" type="line"/>
-      <point x="-280" y="529"/>
-      <point x="-238" y="597"/>
-      <point x="-208" y="622" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="-179" y="647"/>
-      <point x="-104" y="675"/>
-      <point x="-60" y="675" type="qcurve" smooth="yes"/>
-      <point x="-13" y="675"/>
-      <point x="58" y="643"/>
-      <point x="81" y="615" type="qcurve" smooth="yes"/>
-      <point x="100" y="591"/>
-      <point x="119" y="526"/>
-      <point x="118" y="487" type="qcurve"/>
-      <point x="10" y="487" type="line"/>
-      <point x="10" y="507"/>
-      <point x="4" y="543"/>
-      <point x="-4" y="557" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="-13" y="571"/>
-      <point x="-43" y="587"/>
-      <point x="-66" y="587" type="qcurve" smooth="yes"/>
-      <point x="-89" y="587"/>
-      <point x="-125" y="571"/>
-      <point x="-138" y="557" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="-152" y="543"/>
-      <point x="-173" y="507"/>
-      <point x="-180" y="487" type="qcurve"/>
+      <point x="-395" y="488" type="line"/>
+      <point x="-383" y="529"/>
+      <point x="-341" y="597"/>
+      <point x="-311" y="622" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="-282" y="647"/>
+      <point x="-207" y="675"/>
+      <point x="-163" y="675" type="qcurve" smooth="yes"/>
+      <point x="-116" y="675"/>
+      <point x="-45" y="643"/>
+      <point x="-22" y="615" type="qcurve" smooth="yes"/>
+      <point x="-3" y="591"/>
+      <point x="16" y="526"/>
+      <point x="15" y="487" type="qcurve"/>
+      <point x="-93" y="487" type="line"/>
+      <point x="-93" y="507"/>
+      <point x="-99" y="543"/>
+      <point x="-107" y="557" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="-116" y="571"/>
+      <point x="-146" y="587"/>
+      <point x="-169" y="587" type="qcurve" smooth="yes"/>
+      <point x="-192" y="587"/>
+      <point x="-228" y="571"/>
+      <point x="-241" y="557" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="-255" y="543"/>
+      <point x="-276" y="507"/>
+      <point x="-283" y="487" type="qcurve"/>
     </contour>
     <contour>
-      <point x="-221" y="-31" type="line"/>
-      <point x="-209" y="10"/>
-      <point x="-167" y="78"/>
-      <point x="-137" y="103" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="-108" y="128"/>
-      <point x="-33" y="156"/>
-      <point x="11" y="156" type="qcurve" smooth="yes"/>
-      <point x="56" y="156"/>
-      <point x="127" y="126"/>
-      <point x="149" y="100" type="qcurve" smooth="yes"/>
-      <point x="170" y="75"/>
-      <point x="191" y="8"/>
-      <point x="190" y="-32" type="qcurve"/>
-      <point x="81" y="-32" type="line"/>
-      <point x="81" y="-12"/>
-      <point x="75" y="24"/>
-      <point x="67" y="38" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="58" y="52"/>
-      <point x="29" y="68"/>
-      <point x="5" y="68" type="qcurve" smooth="yes"/>
-      <point x="-18" y="68"/>
-      <point x="-54" y="52"/>
-      <point x="-67" y="38" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="-81" y="24"/>
-      <point x="-101" y="-13"/>
-      <point x="-108" y="-32" type="qcurve"/>
+      <point x="-324" y="-31" type="line"/>
+      <point x="-312" y="10"/>
+      <point x="-270" y="78"/>
+      <point x="-240" y="103" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="-211" y="128"/>
+      <point x="-136" y="156"/>
+      <point x="-92" y="156" type="qcurve" smooth="yes"/>
+      <point x="-47" y="156"/>
+      <point x="24" y="126"/>
+      <point x="46" y="100" type="qcurve" smooth="yes"/>
+      <point x="67" y="75"/>
+      <point x="88" y="8"/>
+      <point x="87" y="-32" type="qcurve"/>
+      <point x="-22" y="-32" type="line"/>
+      <point x="-22" y="-12"/>
+      <point x="-28" y="24"/>
+      <point x="-36" y="38" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="-45" y="52"/>
+      <point x="-74" y="68"/>
+      <point x="-98" y="68" type="qcurve" smooth="yes"/>
+      <point x="-121" y="68"/>
+      <point x="-157" y="52"/>
+      <point x="-170" y="38" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="-184" y="24"/>
+      <point x="-204" y="-13"/>
+      <point x="-211" y="-32" type="qcurve"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/RobotoMono-ThinItalic.ufo/glyphs/uni0489.glif
+++ b/sources/RobotoMono-ThinItalic.ufo/glyphs/uni0489.glif
@@ -1,63 +1,63 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni0489" format="2">
-  <advance width="10"/>
+  <advance width="1202"/>
   <unicode hex="0489"/>
   <outline>
     <contour>
-      <point x="956" y="-59" type="line"/>
-      <point x="966" y="-75" type="line"/>
-      <point x="791" y="-413" type="line"/>
-      <point x="693" y="-413" type="line"/>
-      <point x="822" y="-61" type="line"/>
+      <point x="547" y="-59" type="line"/>
+      <point x="557" y="-75" type="line"/>
+      <point x="382" y="-413" type="line"/>
+      <point x="284" y="-413" type="line"/>
+      <point x="413" y="-61" type="line"/>
     </contour>
     <contour>
-      <point x="976" y="1125" type="line"/>
-      <point x="965" y="1141" type="line"/>
-      <point x="1140" y="1478" type="line"/>
-      <point x="1237" y="1478" type="line"/>
-      <point x="1109" y="1127" type="line"/>
+      <point x="567" y="1125" type="line"/>
+      <point x="556" y="1141" type="line"/>
+      <point x="731" y="1478" type="line"/>
+      <point x="828" y="1478" type="line"/>
+      <point x="700" y="1127" type="line"/>
     </contour>
     <contour>
-      <point x="1544" y="631" type="line"/>
-      <point x="1557" y="642" type="line"/>
-      <point x="1863" y="517" type="line"/>
-      <point x="1846" y="422" type="line"/>
-      <point x="1523" y="492" type="line"/>
+      <point x="1135" y="631" type="line"/>
+      <point x="1148" y="642" type="line"/>
+      <point x="1454" y="517" type="line"/>
+      <point x="1437" y="422" type="line"/>
+      <point x="1114" y="492" type="line"/>
     </contour>
     <contour>
-      <point x="385" y="433" type="line"/>
-      <point x="372" y="422" type="line"/>
-      <point x="65" y="547" type="line"/>
-      <point x="83" y="642" type="line"/>
-      <point x="406" y="572" type="line"/>
+      <point x="-24" y="433" type="line"/>
+      <point x="-37" y="422" type="line"/>
+      <point x="-344" y="547" type="line"/>
+      <point x="-326" y="642" type="line"/>
+      <point x="-3" y="572" type="line"/>
     </contour>
     <contour>
-      <point x="1376" y="1003" type="line"/>
-      <point x="1380" y="1018" type="line"/>
-      <point x="1717" y="1171" type="line"/>
-      <point x="1774" y="1100" type="line"/>
-      <point x="1458" y="903" type="line"/>
+      <point x="967" y="1003" type="line"/>
+      <point x="971" y="1018" type="line"/>
+      <point x="1308" y="1171" type="line"/>
+      <point x="1365" y="1100" type="line"/>
+      <point x="1049" y="903" type="line"/>
     </contour>
     <contour>
-      <point x="545" y="20" type="line"/>
-      <point x="541" y="4" type="line"/>
-      <point x="206" y="-149" type="line"/>
-      <point x="147" y="-77" type="line"/>
-      <point x="463" y="120" type="line"/>
+      <point x="136" y="20" type="line"/>
+      <point x="132" y="4" type="line"/>
+      <point x="-203" y="-149" type="line"/>
+      <point x="-262" y="-77" type="line"/>
+      <point x="54" y="120" type="line"/>
     </contour>
     <contour>
-      <point x="557" y="860" type="line"/>
-      <point x="539" y="862" type="line"/>
-      <point x="450" y="1192" type="line"/>
-      <point x="523" y="1258" type="line"/>
-      <point x="667" y="957" type="line"/>
+      <point x="148" y="860" type="line"/>
+      <point x="130" y="862" type="line"/>
+      <point x="41" y="1192" type="line"/>
+      <point x="114" y="1258" type="line"/>
+      <point x="258" y="957" type="line"/>
     </contour>
     <contour>
-      <point x="1362" y="161" type="line"/>
-      <point x="1380" y="159" type="line"/>
-      <point x="1470" y="-170" type="line"/>
-      <point x="1396" y="-238" type="line"/>
-      <point x="1253" y="63" type="line"/>
+      <point x="953" y="161" type="line"/>
+      <point x="971" y="159" type="line"/>
+      <point x="1061" y="-170" type="line"/>
+      <point x="987" y="-238" type="line"/>
+      <point x="844" y="63" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/RobotoMono-ThinItalic.ufo/glyphs/uni049E_.glif
+++ b/sources/RobotoMono-ThinItalic.ufo/glyphs/uni049E_.glif
@@ -1,30 +1,30 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni049E" format="2">
-  <advance width="1222"/>
+  <advance width="1202"/>
   <unicode hex="049E"/>
   <outline>
     <contour>
-      <point x="696" y="1105" type="line"/>
-      <point x="401" y="1105" type="line"/>
-      <point x="343" y="764" type="line"/>
-      <point x="548" y="764" type="line"/>
-      <point x="1219" y="1455" type="line"/>
-      <point x="1288" y="1454" type="line"/>
-      <point x="588" y="725" type="line"/>
-      <point x="1078" y="0" type="line"/>
-      <point x="1014" y="0" type="line"/>
-      <point x="530" y="711" type="line"/>
-      <point x="335" y="711" type="line"/>
-      <point x="212" y="0" type="line"/>
-      <point x="160" y="0" type="line"/>
-      <point x="350" y="1105" type="line"/>
-      <point x="125" y="1105" type="line"/>
-      <point x="133" y="1159" type="line"/>
-      <point x="360" y="1159" type="line"/>
-      <point x="411" y="1456" type="line"/>
-      <point x="462" y="1456" type="line"/>
-      <point x="411" y="1159" type="line"/>
-      <point x="704" y="1159" type="line"/>
+      <point x="686" y="1105" type="line"/>
+      <point x="391" y="1105" type="line"/>
+      <point x="333" y="764" type="line"/>
+      <point x="538" y="764" type="line"/>
+      <point x="1209" y="1455" type="line"/>
+      <point x="1278" y="1454" type="line"/>
+      <point x="578" y="725" type="line"/>
+      <point x="1068" y="0" type="line"/>
+      <point x="1004" y="0" type="line"/>
+      <point x="520" y="711" type="line"/>
+      <point x="325" y="711" type="line"/>
+      <point x="202" y="0" type="line"/>
+      <point x="150" y="0" type="line"/>
+      <point x="340" y="1105" type="line"/>
+      <point x="115" y="1105" type="line"/>
+      <point x="123" y="1159" type="line"/>
+      <point x="350" y="1159" type="line"/>
+      <point x="401" y="1456" type="line"/>
+      <point x="452" y="1456" type="line"/>
+      <point x="401" y="1159" type="line"/>
+      <point x="694" y="1159" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/RobotoMono-ThinItalic.ufo/glyphs/uni049F_.glif
+++ b/sources/RobotoMono-ThinItalic.ufo/glyphs/uni049F_.glif
@@ -1,30 +1,30 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni049F" format="2">
-  <advance width="1222"/>
+  <advance width="1202"/>
   <unicode hex="049F"/>
   <outline>
     <contour>
-      <point x="787" y="1264" type="line"/>
-      <point x="438" y="1264" type="line"/>
-      <point x="308" y="510" type="line"/>
-      <point x="458" y="628" type="line"/>
-      <point x="1044" y="1082" type="line"/>
-      <point x="1130" y="1082" type="line"/>
-      <point x="533" y="619" type="line"/>
-      <point x="971" y="0" type="line"/>
-      <point x="903" y="0" type="line"/>
-      <point x="491" y="585" type="line"/>
-      <point x="297" y="444" type="line"/>
-      <point x="220" y="0" type="line"/>
-      <point x="166" y="0" type="line"/>
-      <point x="383" y="1264" type="line"/>
-      <point x="216" y="1264" type="line"/>
-      <point x="224" y="1318" type="line"/>
-      <point x="392" y="1318" type="line"/>
-      <point x="430" y="1536" type="line"/>
-      <point x="485" y="1536" type="line"/>
-      <point x="447" y="1318" type="line"/>
-      <point x="795" y="1318" type="line"/>
+      <point x="777" y="1264" type="line"/>
+      <point x="428" y="1264" type="line"/>
+      <point x="298" y="510" type="line"/>
+      <point x="448" y="628" type="line"/>
+      <point x="1034" y="1082" type="line"/>
+      <point x="1120" y="1082" type="line"/>
+      <point x="523" y="619" type="line"/>
+      <point x="961" y="0" type="line"/>
+      <point x="893" y="0" type="line"/>
+      <point x="481" y="585" type="line"/>
+      <point x="287" y="444" type="line"/>
+      <point x="210" y="0" type="line"/>
+      <point x="156" y="0" type="line"/>
+      <point x="373" y="1264" type="line"/>
+      <point x="206" y="1264" type="line"/>
+      <point x="214" y="1318" type="line"/>
+      <point x="382" y="1318" type="line"/>
+      <point x="420" y="1536" type="line"/>
+      <point x="475" y="1536" type="line"/>
+      <point x="437" y="1318" type="line"/>
+      <point x="785" y="1318" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/RobotoMono-ThinItalic.ufo/glyphs/uni20A_B_.glif
+++ b/sources/RobotoMono-ThinItalic.ufo/glyphs/uni20A_B_.glif
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni20AB" format="2">
-  <advance width="1232"/>
+  <advance width="1202"/>
   <unicode hex="20AB"/>
   <outline>
-    <component base="d"/>
+    <component base="d" xOffset="-15"/>
     <component base="crossbar" xOffset="355" yOffset="560"/>
-    <component base="underscore" xOffset="-74" yOffset="-156"/>
+    <component base="underscore" xOffset="-89" yOffset="-156"/>
   </outline>
 </glyph>

--- a/sources/RobotoMono-ThinItalic.ufo/glyphs/uniF_F_F_D_.glif
+++ b/sources/RobotoMono-ThinItalic.ufo/glyphs/uniF_F_F_D_.glif
@@ -1,77 +1,77 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uniFFFD" format="2">
-  <advance width="1229"/>
+  <advance width="1202"/>
   <unicode hex="FFFD"/>
   <outline>
     <contour>
-      <point x="610" y="1618" type="line"/>
-      <point x="1199" y="643" type="line"/>
-      <point x="610" y="-332" type="line"/>
-      <point x="15" y="643" type="line"/>
+      <point x="595" y="1618" type="line"/>
+      <point x="1184" y="643" type="line"/>
+      <point x="595" y="-332" type="line"/>
+      <point x="0" y="643" type="line"/>
     </contour>
     <contour>
-      <point x="713" y="392" type="line"/>
-      <point x="713" y="417"/>
-      <point x="719" y="456"/>
-      <point x="725.0" y="471.5" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="731" y="487"/>
-      <point x="748" y="516"/>
-      <point x="759" y="532" type="qcurve" smooth="yes"/>
-      <point x="781" y="563"/>
-      <point x="826" y="618"/>
-      <point x="844.0" y="646.5" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="862" y="675"/>
-      <point x="885" y="739"/>
-      <point x="885" y="780" type="qcurve" smooth="yes"/>
-      <point x="885" y="844"/>
-      <point x="848" y="947"/>
-      <point x="813.5" y="983.5" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="779" y="1020"/>
-      <point x="677" y="1059"/>
-      <point x="613" y="1059" type="qcurve" smooth="yes"/>
-      <point x="557" y="1059"/>
-      <point x="460" y="1029"/>
-      <point x="423.5" y="996.5" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="387" y="964"/>
-      <point x="344" y="863"/>
-      <point x="343" y="793" type="qcurve"/>
-      <point x="546" y="793" type="line"/>
-      <point x="548" y="848"/>
-      <point x="589" y="896"/>
-      <point x="613" y="896" type="qcurve" smooth="yes"/>
-      <point x="650" y="896"/>
-      <point x="682" y="832"/>
-      <point x="682" y="780" type="qcurve" smooth="yes"/>
-      <point x="682" y="754"/>
-      <point x="665" y="703"/>
-      <point x="653.0" y="679.5" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="641" y="656"/>
-      <point x="614" y="617"/>
-      <point x="604" y="604" type="qcurve" smooth="yes"/>
-      <point x="575" y="568"/>
-      <point x="540" y="528"/>
-      <point x="529.5" y="509.0" type="qcurve" smooth="yes" name="inserted"/>
-      <point x="519" y="490"/>
-      <point x="511" y="440"/>
-      <point x="511" y="392" type="qcurve"/>
+      <point x="698" y="392" type="line"/>
+      <point x="698" y="417"/>
+      <point x="704" y="456"/>
+      <point x="710.0" y="472" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="716" y="487"/>
+      <point x="733" y="516"/>
+      <point x="744" y="532" type="qcurve" smooth="yes"/>
+      <point x="766" y="563"/>
+      <point x="811" y="618"/>
+      <point x="829.0" y="647" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="847" y="675"/>
+      <point x="870" y="739"/>
+      <point x="870" y="780" type="qcurve" smooth="yes"/>
+      <point x="870" y="844"/>
+      <point x="833" y="947"/>
+      <point x="799" y="984" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="764" y="1020"/>
+      <point x="662" y="1059"/>
+      <point x="598" y="1059" type="qcurve" smooth="yes"/>
+      <point x="542" y="1059"/>
+      <point x="445" y="1029"/>
+      <point x="409" y="997" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="372" y="964"/>
+      <point x="329" y="863"/>
+      <point x="328" y="793" type="qcurve"/>
+      <point x="531" y="793" type="line"/>
+      <point x="533" y="848"/>
+      <point x="574" y="896"/>
+      <point x="598" y="896" type="qcurve" smooth="yes"/>
+      <point x="635" y="896"/>
+      <point x="667" y="832"/>
+      <point x="667" y="780" type="qcurve" smooth="yes"/>
+      <point x="667" y="754"/>
+      <point x="650" y="703"/>
+      <point x="638.0" y="680" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="626" y="656"/>
+      <point x="599" y="617"/>
+      <point x="589" y="604" type="qcurve" smooth="yes"/>
+      <point x="560" y="568"/>
+      <point x="525" y="528"/>
+      <point x="515" y="509.0" type="qcurve" smooth="yes" name="inserted"/>
+      <point x="504" y="490"/>
+      <point x="496" y="440"/>
+      <point x="496" y="392" type="qcurve"/>
     </contour>
     <contour>
-      <point x="713" y="301" type="line"/>
-      <point x="511" y="301" type="line"/>
-      <point x="511" y="131" type="line"/>
-      <point x="713" y="131" type="line"/>
+      <point x="698" y="301" type="line"/>
+      <point x="496" y="301" type="line"/>
+      <point x="496" y="131" type="line"/>
+      <point x="698" y="131" type="line"/>
     </contour>
     <contour>
-      <point x="605" y="-551" type="line"/>
-      <point x="609" y="-551" type="line"/>
-      <point x="609" y="-555" type="line"/>
-      <point x="605" y="-555" type="line"/>
+      <point x="590" y="-551" type="line"/>
+      <point x="594" y="-551" type="line"/>
+      <point x="594" y="-555" type="line"/>
+      <point x="590" y="-555" type="line"/>
     </contour>
     <contour>
-      <point x="603" y="2163" type="line"/>
-      <point x="607" y="2163" type="line"/>
-      <point x="607" y="2159" type="line"/>
-      <point x="603" y="2159" type="line"/>
+      <point x="588" y="2163" type="line"/>
+      <point x="592" y="2163" type="line"/>
+      <point x="592" y="2159" type="line"/>
+      <point x="588" y="2159" type="line"/>
     </contour>
   </outline>
 </glyph>


### PR DESCRIPTION
/hyphen/f/uni00AD/Omicrontonos/Omegatonos/uni049E/uni049F/Dcroat/Eth/hbar/dcroat/uni20AB/tcaron/Epsilontonos/Etatonos/Iotatonos/Upsilontonos/dcaron/lcaron/ldot/exclamdbl/

Some 'comb' not on zero width.  Left comb as they are because a change may affect accent placement.